### PR TITLE
Restructure README and add comprehensive documentation

### DIFF
--- a/content-ops/README.md
+++ b/content-ops/README.md
@@ -1,205 +1,174 @@
 # content-ops
 
-A Claude Code plugin for content creation and management on static site blogs. Handles writing, translation, research, linking, style review, knowledge indexing, and tracker updates.
+> **Work in progress.** The plugin works — but it's still being polished. Some defaults are borrowed from the project it was built on and aren't fully agnostic yet. Expect rough edges and active iteration. Follow progress on [LinkedIn](https://linkedin.com/in/pcamarajr).
+
+A Claude Code plugin that gives you a team of AI writers running from your strategy — so you stay focused on what to build, not on writing every word.
+
+You define your content pillars, goals, and style. content-ops handles research, writing, translation, internal linking, fact-checking, and indexing. You review, approve, and ship.
+
+Works with any markdown-based static site (Astro, Next.js with Contentlayer, Hugo, and others) — if your content has frontmatter and a body, it should work.
+
+---
+
+## What it does
+
+Instead of writing each article from scratch, you run a single command and get a research-backed, style-reviewed, internally-linked draft — ready for your review.
+
+The typical workflow:
+
+- Add ideas to a **backlog** as they come to you
+- When ready, ask content-ops to pick from the backlog — or kick off an interactive session for something specific
+- Claude researches, drafts, checks facts, enforces your style, links to related content, and updates your trackers
+- You review the PR, iterate if needed, and ship
+
+It's the same loop you'd run with a copywriter — but always available, always on-brief.
+
+---
+
+## Quick start
+
+### 1. Install
+
+Copy the plugin into your project:
+
+```bash
+cp -r content-ops/ your-project/.claude/plugins/content-ops
+```
+
+Or install via the Claude Code plugin marketplace:
+
+```
+/plugin marketplace add pcamarajr/content-stack
+/plugin install content-ops@content-stack
+```
+
+### 2. Init
+
+Run the setup wizard inside Claude Code:
+
+```
+/init
+```
+
+This walks you through six setup rounds: your author info and languages, content types and paths, style guide and reference articles, content strategy and pillars, infrastructure (backlog, trackers), and optionally image generation.
+
+You can run rounds individually:
+
+```
+/init project
+/init content-types
+/init style
+/init strategy
+/init infra
+/init images
+```
+
+### 3. Index your content
+
+```
+/reindex
+```
+
+Scans your existing content and builds `.content-ops/content-index.json` — the knowledge layer the agents use for linking and discovery.
+
+### 4. Write something
+
+```
+/write-content article "Getting started with Docker"
+/write-content backlog 3
+/write-content
+```
+
+That's it. Claude takes it from there.
+
+---
+
+## How it works
+
+content-ops is a **phase-based orchestrator**. When you run `/write-content`, it coordinates a pipeline of specialized agents — each focused on one job.
+
+```mermaid
+flowchart TD
+    User([You]) -->|/write-content| WC[write-content skill]
+
+    WC --> P1[Phase 1\nParse arguments]
+    P1 --> P2[Phase 2\nLoad config + guidelines]
+    P2 --> P3[Phase 3\nPlan topic]
+    P3 --> P4[Phase 4\nResearch]
+    P4 --> P5[Phase 5\nDraft]
+    P5 --> P55[Phase 5.5\nGenerate images\noptional]
+    P55 --> P6[Phase 6\nStyle review]
+    P6 --> P7[Phase 7\nGlossary check]
+    P7 --> P8[Phase 8\nBidirectional linking]
+    P8 --> P9[Phase 9\nReindex + commit]
+
+    P4 <-->|cache hit/miss| RC[(Research cache\n.content-ops/research-cache/)]
+    P5 --> DW[draft-writer agent]
+    P4 --> CR[content-researcher agent]
+    P6 --> SE[style-enforcer agent]
+    P7 --> GC[glossary-creator agent]
+    P8 --> CL[content-linker agent]
+    CL <-->|reads| CI[(Content index\n.content-ops/content-index.json)]
+
+    P9 --> Commit([git commit])
+```
+
+All knowledge lives in files — no embeddings, no vector DBs, no external APIs required for the core pipeline.
+
+→ [Full technical walkthrough](./docs/how-it-works.md)
+
+---
+
+## Skills at a glance
+
+| Skill | What you type | What happens |
+|---|---|---|
+| `/init` | `/init` or `/init [round]` | Setup wizard — creates config, guides, and trackers |
+| `/write-content` | `/write-content article "Topic"` | Full pipeline: research → draft → style → link → commit |
+| `/translate` | `/translate es` | Localize content to a target language |
+| `/fact-check` | `/fact-check path/to/article.md` | Verify every claim against trusted sources |
+| `/review-content` | `/review-content path/to/article.md` | Style, tone, structure, and linking audit |
+| `/suggest-content` | `/suggest-content 5` | Suggest next articles from gaps in your strategy |
+| `/reindex` | `/reindex` | Rebuild the content index from current files |
+
+→ [Full skills reference](./docs/skills.md)
+
+---
 
 ## Requirements
 
 - [Claude Code](https://claude.ai/code) CLI
 - Node.js 22+
-- pnpm (or npm/yarn)
+- A markdown-based static site with frontmatter content
 
-No API keys or external services required for the knowledge layer — it uses file-based content index and research cache.
+No API keys needed for the core workflow. Image generation is optional and uses Google Gemini or OpenAI when enabled.
 
-**Image generation** is optional. When enabled via `/init images`, it uses the Google Gemini API (Nano Banana) or OpenAI GPT Image to generate article images. Requires a `GEMINI_API_KEY` or `OPENAI_API_KEY` environment variable.
+---
 
-## Installation
+## Documentation
 
-1. Copy the `content-ops/` directory into your project's `.claude/plugins/` folder:
+| | |
+|---|---|
+| [How it works](./docs/how-it-works.md) | Architecture, agent pipeline, phase breakdown |
+| [Configuration](./docs/configuration.md) | Full config schema and `.content-ops/` layout |
+| [Skills](./docs/skills.md) | Every skill with examples and options |
+| [Agents](./docs/agents.md) | What each agent does and when it runs |
+| [Knowledge layer](./docs/knowledge-layer.md) | Content index, research cache, and how linking works |
 
-```text
-your-project/
-└── .claude/
-    └── plugins/
-        └── content-ops/    ← this plugin
-```
+---
 
-2. Copy the example config to `.content-ops/config.md` and customize:
+## Status
 
-```bash
-cp .claude/plugins/content-ops/config.example.md .content-ops/config.md
-```
+This plugin is **actively being developed**. Current state:
 
-3. Edit `.content-ops/config.md` with your project-specific values (content paths, languages, author, etc.).
+- **Works:** init wizard, write-content pipeline, translation, fact-check, review, suggest, reindex, internal linking, research cache
+- **In progress:** removing project-specific assumptions to make it fully framework-agnostic
+- **Not yet:** automation / CI mode, public examples, full test coverage
 
-4. Run `/init` (or `/init project`) to create or verify the config, then complete the remaining rounds as needed. Alternatively, run `/reindex` to generate the initial content index (`.content-ops/content-index.json`).
+Feedback and issues welcome on [GitHub](https://github.com/pcamarajr/content-stack/issues).
 
-**Hooks:** Hooks are bundled in the plugin and load automatically when the plugin is enabled. No manual merge into `.claude/settings.json` needed. The plugin provides:
-
-- `hooks/hooks.json` — SessionStart (config display), PostToolUse (Edit|Write, Bash), Stop (content verification prompt)
-- `hooks-handlers/` — `post-write-content.sh`, `post-commit-index.sh`, `post-commit-build.sh` (scripts referenced via `${CLAUDE_PLUGIN_ROOT}`)
-
-**Note:** `post-commit-build.sh` runs `pnpm build` after every git commit. If you don't use pnpm, you can remove or replace this hook in `hooks/hooks.json`.
-
-## Configuration
-
-All project-specific values live in `.content-ops/config.md` (YAML frontmatter format). The config file is **tracked in git** for cloud-friendly runs. Skills read this file at runtime. If the config file doesn't exist, skills will stop and tell you how to create it — run `/init` or copy the example.
-
-See `config.example.md` for the full schema and all available fields.
-
-### Key Configuration Fields
-
-| Field | Description |
-| ---- | ----- |
-| `author` | Attribution line for all content |
-| `languages` | Supported language codes (e.g., `["en", "es"]`) |
-| `content_types` | Per-type config: path, guidelines file, word range, frontmatter fields |
-| `backlog_file` | Path to content backlog tracker (default `.content-ops/backlog.md`) |
-| `translation_tracker_file` | Path to translation status tracker (default `.content-ops/translation-tracker.md`) |
-| `content_strategy` | Path to content strategy file (default `.content-ops/strategy.md`) |
-| `content_pillars_path` | Directory containing content pillar files (default `.content-ops/pillars`) |
-| `localization_guides_path` | Directory for per-language localization guides (default `.content-ops/localization`) |
-| `reference_content` | Files to read for tone calibration |
-| `content_index_path` | Path to content index JSON (default `.content-ops/content-index.json`) |
-| `research_cache_path` | Path to research cache directory (default `.content-ops/research-cache`) |
-| `linking_max_candidates` | Max candidates before LLM ranking (optional, default 50) |
-| `linking_max_links` | Max links per article (optional, default 10) |
-| `image_generation` | Image generation config block (optional — run `/init images` to configure) |
-
-### .content-ops/ Layout
-
-All configurable files live under `.content-ops/` by default. The entire directory is tracked in git.
-
-| File/Dir | Purpose |
-| ---- | ----- |
-| `config.md` | Plugin configuration |
-| `backlog.md` | Content backlog tracker |
-| `translation-tracker.md` | Translation status tracker |
-| `strategy.md` | Content strategy / editorial plan |
-| `pillars/` | Content pillar files |
-| `localization/` | Per-language localization guides |
-| `content-index.json` | Generated by `/reindex` |
-| `research-cache/` | Cached research per topic |
-
-### Content Strategy & Pillars
-
-The plugin uses a two-level content planning system:
-
-- **`content_strategy`** — A single file defining your high-level editorial plan: what topics to cover, gaps to fill, themes, and goals.
-- **`content_pillars_path`** — A directory of files, each defining a content pillar with topics, progression, and detailed objectives. Optional — if not set, `/suggest-content` works from the strategy file + existing content only.
-
-The `/suggest-content` skill reads both to identify coverage gaps and prioritize what to write next. The `/write-content` skill reads them for topic context when drafting articles.
-
-## Init — Setup Wizard
-
-The `/init` skill is the recommended way to initialize content-ops in your project.
-
-**Invocation:**
-
-- `/init` — Shows the setup status dashboard
-- `/init [round]` — Runs a specific setup step
-
-**Rounds (in order):** `project` → `content-types` → `style` → `strategy` → `infra` → `images` _(optional)_
-
-Each round reads from `skills/init/rounds/<round>.md` (relative to plugin root).
-
-**What init does:** Creates or updates `.content-ops/config.md` and, in the infra round, can create bootstrap files under `.content-ops/` (backlog, translation tracker, localization guides). After running rounds, run `/reindex` to generate the content index.
-
-**Status dashboard:** When you run `/init` with no arguments, it shows completion status per round:
-
-- project: author + languages set
-- content-types: at least one type with path
-- style: reference_content + guidelines
-- strategy: content_strategy file exists
-- infra: backlog and translation tracker exist
-- images: image_generation section in config + guidelines file exists
-
-Config is read from `.content-ops/config.md`.
-
-**Installation flow:** After copying the plugin, run `/init` (or `/init project`) to create `.content-ops/config.md` and then complete the remaining rounds as needed. You can instead copy the example config to `.content-ops/config.md` and edit by hand, then use `/init` to check status or run specific rounds.
-
-## Skills
-
-### User-Invocable
-
-| Skill | Usage | Description |
-| ---- | ----- | ----- |
-| `/init` | `/init` or `/init [round]` | Setup wizard — creates config and bootstrap files |
-| `/write-content` | `/write-content article "Topic"` | Create articles or glossary entries. Handles research, writing, style review, linking, trackers, and indexing. |
-| `/translate` | `/translate es` | Localize content to a target language with glossary, linking, and tracker updates. |
-| `/fact-check` | `/fact-check src/content/articles/en/my-article.md` | Verify every claim in a content file against trusted sources. |
-| `/review-content` | `/review-content src/content/articles/en/my-article.md` | Review content for tone, style, structure, and linking completeness. |
-| `/suggest-content` | `/suggest-content 5 technical` | Suggest next articles based on content strategy, pillars, and coverage gaps. |
-| `/reindex` | `/reindex` | Rebuild the content index by scanning frontmatter and writing `.content-ops/content-index.json`. |
-
-### Internal (Auto-Loaded)
-
-These skills are loaded automatically by other skills and agents. They are not invoked directly.
-
-| Skill | Purpose |
-| ---- | ----- |
-| `content-inventory` | Current snapshot of all articles and glossary entries per language |
-| `content-style` | Voice, tone, structure, and linking rules for content creation |
-| `content-image-style` | Image generation rules: prompt construction, API patterns, file naming, alt text conventions |
-| `internal-linking` | Bidirectional linking conventions and rules |
-| `update-trackers` | Logic for updating content backlog and translation tracker |
-
-## Agents
-
-| Agent | Description |
-| ---- | ----- |
-| `content-researcher` | Fact verification with file-based research cache (avoids re-verifying known facts) |
-| `content-linker` | Bidirectional linking via content-index.json (reads index, edits only matched files) |
-| `style-enforcer` | Style review against configurable guidelines and reference content |
-| `image-generator` | AI image generation — builds prompts from article content and style guide, calls API, saves files |
-
-## File-Based Knowledge Layer
-
-Zero-dependency, file-based approach — no MCP server, no embeddings, no API keys.
-
-### Content Index (`.content-ops/content-index.json`)
-
-Generated by `/reindex`. Contains per-language metadata for all articles and glossary entries: slug, path, type, lang, title, excerpt, optional tags, optional translationKey. The `content-linker` agent reads this file, filters candidates, ranks in one LLM pass (capped by `linking_max_candidates` and `linking_max_links`), then edits only the selected files.
-
-### Research Cache (`.content-ops/research-cache/`)
-
-One JSON file per researched topic (e.g., `proof-of-work.json`). The `content-researcher` agent reads cache files before web search and writes new findings after research. TTL controlled by `research_cache_ttl_days` in config.
-
-Both the index and cache are committed to git for cross-session portability.
-
-## Directory Structure
-
-```text
-content-ops/
-├── .claude-plugin/
-│   └── plugin.json              ← Plugin manifest
-├── hooks/
-│   └── hooks.json               ← Hook config (auto-loaded when plugin enabled)
-├── hooks-handlers/
-│   ├── post-write-content.sh     ← Tracker reminder after Edit|Write
-│   ├── post-commit-index.sh     ← Reindex reminder after git commit
-│   └── post-commit-build.sh      ← pnpm build after git commit
-├── README.md                    ← This file
-├── config.example.md            ← Example configuration
-├── agents/
-│   ├── content-researcher.md
-│   ├── content-linker.md
-│   ├── style-enforcer.md
-│   └── image-generator.md
-└── skills/
-    ├── init/                    ← Setup wizard
-    ├── content-image-style/     ← Image generation rules (auto-loaded)
-    ├── content-inventory/
-    ├── content-style/
-    ├── fact-check/
-    ├── internal-linking/
-    ├── reindex/
-    ├── review-content/
-    ├── suggest-content/
-    ├── translate/
-    ├── update-trackers/
-    └── write-content/
-```
+---
 
 ## License
 
-MIT
+MIT — by [Pedro Camara Jr](https://linkedin.com/in/pcamarajr)

--- a/content-ops/docs/agents.md
+++ b/content-ops/docs/agents.md
@@ -1,0 +1,112 @@
+# Agents
+
+Agents are specialized sub-processes spawned by the `/write-content` and `/translate` skills. Each agent owns a specific part of the pipeline and operates independently — reading from files, doing its job, and writing results back.
+
+You don't invoke agents directly. They're coordinated by the skill orchestrator.
+
+---
+
+## content-researcher
+
+**Phase:** 4 (Research)
+
+Handles fact-finding before drafting begins. Uses a file-based cache to avoid redundant web searches.
+
+**What it does:**
+1. Reads the research cache for the current topic (`research-cache/<topic>.json`)
+2. If cache exists and is fresh (within `research_cache_ttl_days`), uses cached findings
+3. If stale or missing, runs web research and writes new findings to cache
+4. Returns a structured research brief: key facts, sources, claims to verify
+
+**Cache behavior:** Cache files are JSON with a timestamp and TTL. Findings are reused across sessions. The cache is committed to git — portable across machines and Claude Code web sessions.
+
+---
+
+## draft-writer
+
+**Phase:** 5 (Draft)
+
+Writes the actual content file — article or glossary entry.
+
+**What it does:**
+- Reads the research brief from Phase 4
+- Reads your style guidelines and reference articles (for tone calibration)
+- Reads the content strategy and relevant pillar file
+- Writes the file to the correct path with full frontmatter
+
+**Inputs:** research brief, config, guidelines file, reference articles, strategy context
+**Output:** the drafted `.md` file written to the configured content path
+
+---
+
+## image-generator
+
+**Phase:** 5.5 (Images, optional)
+
+Generates article images using the configured AI provider. Only runs if `image_generation` is set in config.
+
+**What it does:**
+1. Reads the drafted article to extract context (title, key points, tone)
+2. Reads the image style guide (`content-image-style` skill)
+3. Builds a detailed image prompt
+4. Calls the configured API (Gemini or OpenAI)
+5. Saves image files (webp) to `output_path`
+6. Writes alt text and updates frontmatter with image paths
+
+**Placement modes:**
+- `hero-only` — one hero image per article
+- `hero-plus-sections` — hero + one image per H2
+- `ai-driven` — agent decides based on content length and structure
+
+**Requires:** `GEMINI_API_KEY` or `OPENAI_API_KEY` environment variable.
+
+---
+
+## style-enforcer
+
+**Phase:** 6 (Style Review)
+
+Reviews the drafted article against your style guide and reference content. Applies fixes directly.
+
+**What it checks:**
+- Sentence length — flags anything over ~20 words, hard limit ~25
+- Paragraph length — flags paragraphs over 4 sentences
+- Plain language — complexity appropriate for your audience
+- H2 structure — 2-4 sections, no H3 headings
+- **The Scope Rule** — if a concept gets 2+ sentences, it probably warrants its own article with an internal link instead
+
+**What it does:** Edits the file in place. Doesn't ask — applies changes according to the style guide, then reports what was changed.
+
+---
+
+## glossary-creator
+
+**Phase:** 7 (Glossary Check)
+
+Scans the drafted article for terms that appear in your content but don't yet have a glossary entry.
+
+**What it does:**
+1. Reads the content index to see existing glossary entries
+2. Scans the article for technical or domain-specific terms
+3. Creates missing glossary entries (full pipeline: draft → style → link)
+4. Updates the content index
+
+This runs automatically after every article — your glossary grows organically as you publish.
+
+---
+
+## content-linker
+
+**Phase:** 8 (Bidirectional Linking)
+
+Adds internal links to the new article, and updates existing articles to link back to it.
+
+**What it does:**
+1. Reads `content-index.json`, filters candidates by language and type (max `linking_max_candidates`)
+2. Runs a single LLM ranking pass to select the most relevant matches (max `linking_max_links`)
+3. Reads only the selected files
+4. Adds links in both directions:
+   - In the new article: inline links to related articles
+   - In existing articles: updated frontmatter `relatedArticles` array and inline links where appropriate
+
+**Why this approach:** Reading every content file to find links would be slow and expensive on large sites. The index-filter-rank pattern keeps linking fast regardless of how many articles you have.

--- a/content-ops/docs/configuration.md
+++ b/content-ops/docs/configuration.md
@@ -1,0 +1,168 @@
+# Configuration
+
+All configuration lives in `.content-ops/config.md` — a YAML frontmatter file tracked in git. Skills read it at runtime. If it doesn't exist, any skill will stop and tell you to run `/init` or copy the example.
+
+The easiest way to create it is the init wizard:
+
+```
+/init
+```
+
+To create it manually, copy the example:
+
+```bash
+cp .claude/plugins/content-ops/config.example.md .content-ops/config.md
+```
+
+---
+
+## Full schema
+
+```yaml
+---
+author: "Your Name"                          # Attribution line for all content
+default_language: "en"                       # Primary language code
+languages:                                   # All supported language codes
+  - en
+  - es
+
+content_types:
+  article:
+    path: src/content/articles               # Directory for article files
+    guidelines: .content-ops/guidelines/articles.md  # Style guide for this type
+    word_range: [800, 1200]                  # Target word count range
+    frontmatter:                             # Fields Claude writes to frontmatter
+      - title
+      - description
+      - pubDate
+      - author
+      - tags
+      - translationKey
+  glossary:
+    path: src/content/glossary
+    guidelines: .content-ops/guidelines/glossary.md
+    word_range: [150, 300]
+    frontmatter:
+      - term
+      - definition
+      - relatedTerms
+      - translationKey
+
+backlog_file: .content-ops/backlog.md
+translation_tracker_file: .content-ops/translation-tracker.md
+content_strategy: .content-ops/strategy.md
+content_pillars_path: .content-ops/pillars
+localization_guides_path: .content-ops/localization
+
+reference_content:                           # Example articles for tone calibration
+  - src/content/articles/en/my-best-article.md
+
+content_index_path: .content-ops/content-index.json
+research_cache_path: .content-ops/research-cache
+research_cache_ttl_days: 30                  # How long cached research stays fresh
+
+linking_max_candidates: 50                   # Max articles considered before LLM ranking
+linking_max_links: 10                        # Max links added per article
+
+image_generation:                            # Optional — configure via /init images
+  provider: gemini                           # gemini or openai
+  model: gemini-2.0-flash-preview-image-generation
+  placement: hero-only                       # hero-only | hero-plus-sections | ai-driven
+  output_path: public/images/articles
+  dimensions:
+    width: 1200
+    height: 630
+---
+```
+
+---
+
+## Field reference
+
+### Core
+
+| Field | Required | Description |
+|---|---|---|
+| `author` | Yes | Attribution written to all content frontmatter |
+| `default_language` | Yes | Primary language for new content |
+| `languages` | Yes | All languages the site supports |
+
+### Content types
+
+Each key under `content_types` defines a type (e.g., `article`, `glossary`). You can add custom types.
+
+| Field | Required | Description |
+|---|---|---|
+| `path` | Yes | Directory where files of this type live |
+| `guidelines` | Yes | Path to the style guide file for this type |
+| `word_range` | No | `[min, max]` target word count |
+| `frontmatter` | No | List of frontmatter fields to write |
+
+### Trackers and strategy
+
+| Field | Default | Description |
+|---|---|---|
+| `backlog_file` | `.content-ops/backlog.md` | Content backlog tracker |
+| `translation_tracker_file` | `.content-ops/translation-tracker.md` | Translation status tracker |
+| `content_strategy` | `.content-ops/strategy.md` | High-level editorial plan |
+| `content_pillars_path` | `.content-ops/pillars` | Directory of content pillar files |
+| `localization_guides_path` | `.content-ops/localization` | Per-language localization guides |
+
+### Knowledge layer
+
+| Field | Default | Description |
+|---|---|---|
+| `content_index_path` | `.content-ops/content-index.json` | Generated content index (written by `/reindex`) |
+| `research_cache_path` | `.content-ops/research-cache` | Cached research findings |
+| `research_cache_ttl_days` | `30` | Days before cached research expires |
+| `reference_content` | — | Files read for tone and style calibration |
+| `linking_max_candidates` | `50` | Max candidates before LLM ranking pass |
+| `linking_max_links` | `10` | Max links added per article |
+
+### Image generation (optional)
+
+| Field | Description |
+|---|---|
+| `provider` | `gemini` or `openai` |
+| `model` | Model ID to use for generation |
+| `placement` | `hero-only`, `hero-plus-sections`, or `ai-driven` |
+| `output_path` | Where to save generated image files |
+| `dimensions` | `width` and `height` in pixels |
+
+Requires `GEMINI_API_KEY` or `OPENAI_API_KEY` environment variable. Configure with `/init images`.
+
+---
+
+## The .content-ops/ directory
+
+Everything content-ops manages lives here. The full directory is tracked in git — making it portable across machines and sessions (including Claude Code on the web).
+
+```
+.content-ops/
+├── config.md                 ← Main configuration (edit this)
+├── backlog.md                ← Your content queue
+├── translation-tracker.md    ← Translation status per article
+├── strategy.md               ← High-level editorial plan
+├── pillars/                  ← One file per content theme/pillar
+│   ├── bitcoin-basics.md
+│   └── lightning-network.md
+├── localization/             ← Per-language guides
+│   ├── es.md
+│   └── pt.md
+├── guidelines/               ← Style guides per content type
+│   ├── articles.md
+│   └── glossary.md
+├── content-index.json        ← Generated by /reindex (don't edit manually)
+└── research-cache/           ← Cached research per topic
+    ├── proof-of-work.json
+    └── lightning-channels.json
+```
+
+### Strategy vs. Pillars
+
+The plugin uses a two-level planning system:
+
+- **`strategy.md`** — Your high-level editorial plan. What topics to cover, goals, gaps to fill.
+- **`pillars/`** — One file per content theme with detailed topic progression and objectives. Optional — `/suggest-content` works without them, just from the strategy file.
+
+The `/suggest-content` skill reads both to identify gaps. The `/write-content` skill reads them for topic context when drafting.

--- a/content-ops/docs/how-it-works.md
+++ b/content-ops/docs/how-it-works.md
@@ -1,0 +1,119 @@
+# How it works
+
+content-ops is built around a **phase-based orchestration model**. Rather than one monolithic prompt, complex tasks are broken into focused phases — each handled by a dedicated agent or skill. This keeps each step predictable, auditable, and independently improvable.
+
+---
+
+## The write-content pipeline
+
+When you run `/write-content`, the skill coordinates a sequence of 9 phases:
+
+```
+Phase 1  → Parse arguments (article / glossary / backlog item)
+Phase 2  → Load config, guidelines, reference content
+Phase 3  → Plan the topic (interactive Q&A or backlog parsing)
+Phase 4  → Research (content-researcher agent + cache)
+Phase 5  → Draft (draft-writer agent)
+Phase 5.5→ Generate images (image-generator agent, optional)
+Phase 6  → Style review (style-enforcer agent)
+Phase 7  → Auto-create missing glossary entries (glossary-creator agent)
+Phase 8  → Bidirectional linking (content-linker agent)
+Phase 9  → Reindex + commit
+```
+
+Each phase reads from files, calls an agent, and writes results back to files. Nothing is held in memory between phases — this makes the pipeline resumable and transparent.
+
+---
+
+## Agents and what they own
+
+| Agent | Phase | Responsibility |
+|---|---|---|
+| `content-researcher` | 4 | Web research + cache read/write |
+| `draft-writer` | 5 | Write the article or glossary entry |
+| `image-generator` | 5.5 | Build image prompts, call API, save files |
+| `style-enforcer` | 6 | Review against style guide + reference articles |
+| `glossary-creator` | 7 | Scan article for terms that need glossary entries |
+| `content-linker` | 8 | Find and add bidirectional links |
+
+---
+
+## Interactive vs. backlog mode
+
+**Interactive mode** (`/write-content article "Topic"`):
+- Phase 3 asks you a few questions about angle, target audience, and key points
+- The rest runs automatically
+
+**Backlog mode** (`/write-content backlog 3`):
+- Reads your backlog file, picks the next N pending items
+- Runs the full pipeline for each item autonomously
+- Each item gets its own git commit — if interrupted, completed items aren't lost
+
+---
+
+## How linking works
+
+The `content-linker` agent uses a two-step approach to avoid reading every file in your content directory:
+
+1. **Filter** — read `content-index.json`, filter candidates by language and type (capped at 50)
+2. **Rank** — single LLM pass to select the most relevant matches (capped at `linking_max_links`, default 10)
+3. **Edit** — read only the selected files, add links bidirectionally (frontmatter arrays + inline)
+
+This means linking scales even on large content sites — the agent only reads files it's actually going to link to.
+
+---
+
+## How research caching works
+
+The `content-researcher` agent writes findings to `.content-ops/research-cache/<topic>.json`. On subsequent runs for the same topic, it reads the cache first and skips re-searching if the findings are fresh (controlled by `research_cache_ttl_days` in config, default 30 days).
+
+The cache is committed to git — so it's portable across machines and sessions, including Claude Code on the web.
+
+---
+
+## Hooks
+
+The plugin auto-loads three hooks — no manual configuration needed:
+
+| Hook | Trigger | What it does |
+|---|---|---|
+| `SessionStart` | Opening Claude Code | Displays your content-ops config summary |
+| `PostToolUse` (Edit/Write) | After file writes | Reminds you to update backlog/translation tracker |
+| `PostToolUse` (Bash/git commit) | After a commit | Suggests running reindex if content changed |
+| `Stop` | Before session ends | Prompts to verify build ran if content was changed |
+
+> **Note:** The `post-commit-build.sh` hook currently runs `pnpm build`. This is a known leftover from the original project. If you don't use pnpm, remove or replace this hook in `hooks/hooks.json`. Full framework-agnostic hooks are in progress.
+
+---
+
+## Auto-loaded skills
+
+Some skills are loaded silently by agents — you never invoke them directly:
+
+| Skill | What it provides |
+|---|---|
+| `content-style` | Voice, tone, sentence rules, structure guidelines |
+| `content-image-style` | Image prompt patterns, file naming, alt text |
+| `content-inventory` | Snapshot of all articles/glossary per language |
+| `internal-linking` | Bidirectional linking conventions |
+| `update-trackers` | Logic for updating backlog and translation tracker |
+
+These exist as separate skills so they can be updated independently without touching agent prompts.
+
+---
+
+## File flow overview
+
+```
+.content-ops/
+├── config.md                 ← Read by every skill at startup
+├── backlog.md                ← Read/written by write-content + update-trackers
+├── translation-tracker.md    ← Read/written by translate + update-trackers
+├── strategy.md               ← Read by suggest-content + write-content
+├── pillars/                  ← Read by suggest-content + write-content
+├── localization/             ← Read by translate agent
+├── content-index.json        ← Written by reindex, read by content-linker
+└── research-cache/           ← Written + read by content-researcher
+```
+
+Everything is plain files tracked in git. No database, no server, no background process.

--- a/content-ops/docs/knowledge-layer.md
+++ b/content-ops/docs/knowledge-layer.md
@@ -1,0 +1,161 @@
+# Knowledge layer
+
+content-ops uses a fully file-based knowledge layer — no database, no embeddings, no vector search, no external APIs. Everything is plain JSON files committed to git.
+
+This means it works offline, it's portable across machines, and it's transparent — you can open any file and see exactly what Claude knows about your content.
+
+---
+
+## Content index
+
+**Location:** `.content-ops/content-index.json` (configurable via `content_index_path`)
+**Written by:** `/reindex`
+**Read by:** `content-linker` agent, `content-inventory` skill, `/suggest-content`
+
+The content index is a JSON file containing metadata for every article and glossary entry in your site, organized by language.
+
+### Structure
+
+```json
+{
+  "en": {
+    "articles": [
+      {
+        "slug": "getting-started-with-bitcoin",
+        "path": "src/content/articles/en/getting-started-with-bitcoin.md",
+        "type": "article",
+        "lang": "en",
+        "title": "Getting Started with Bitcoin",
+        "excerpt": "A beginner's guide to understanding Bitcoin...",
+        "tags": ["bitcoin", "beginner", "crypto"],
+        "translationKey": "getting-started-with-bitcoin"
+      }
+    ],
+    "glossary": [
+      {
+        "slug": "proof-of-work",
+        "path": "src/content/glossary/en/proof-of-work.md",
+        "type": "glossary",
+        "lang": "en",
+        "title": "Proof of Work",
+        "excerpt": "A consensus mechanism used to validate transactions...",
+        "tags": ["consensus", "mining"],
+        "translationKey": "proof-of-work"
+      }
+    ]
+  },
+  "es": {
+    "articles": [...],
+    "glossary": [...]
+  }
+}
+```
+
+### How linking uses it
+
+The `content-linker` agent uses a two-step approach:
+
+1. **Filter** — load the index, filter by language and type, cap at `linking_max_candidates` (default 50)
+2. **Rank** — single LLM pass over filtered candidates, select top `linking_max_links` (default 10)
+3. **Read** — only open the files that were selected in step 2
+4. **Link** — edit those files to add bidirectional links
+
+This scales to large sites. The agent never reads every file — it reads the index (one file), ranks candidates (one LLM call), then reads only the matched files.
+
+### Keeping it current
+
+Run `/reindex` after:
+- Adding content files manually
+- Renaming or deleting articles
+- Updating article titles or tags
+- Bulk imports
+
+After `/write-content` runs, reindex happens automatically as the last phase.
+
+---
+
+## Research cache
+
+**Location:** `.content-ops/research-cache/` (configurable via `research_cache_path`)
+**Written by:** `content-researcher` agent
+**Read by:** `content-researcher` agent
+
+One JSON file per researched topic. The file name is derived from the topic slug.
+
+### Structure
+
+```json
+{
+  "topic": "proof-of-work",
+  "cached_at": "2025-01-15T10:30:00Z",
+  "ttl_days": 30,
+  "findings": {
+    "summary": "Proof of Work is a consensus mechanism...",
+    "key_facts": [
+      "Bitcoin uses SHA-256 for its PoW algorithm",
+      "Difficulty adjusts every 2016 blocks (~2 weeks)",
+      "The first PoW system was Hashcash, created by Adam Back in 1997"
+    ],
+    "sources": [
+      "https://bitcoin.org/bitcoin.pdf",
+      "https://en.bitcoin.it/wiki/Proof_of_work"
+    ],
+    "claims_verified": true
+  }
+}
+```
+
+### TTL behavior
+
+When `content-researcher` starts:
+1. Check if `research-cache/<topic>.json` exists
+2. If it exists, check `cached_at` + `ttl_days` against today
+3. If fresh → use cached findings, skip web search
+4. If stale or missing → run web research, write new cache file
+
+The default TTL is 30 days, configurable via `research_cache_ttl_days` in config. Set it lower for fast-moving topics, higher for evergreen content.
+
+### Cross-session portability
+
+Cache files are committed to git. This means:
+- Research done on your laptop is available in a Claude Code web session
+- Team members benefit from each other's research
+- Restarting Claude Code never loses cached findings
+
+---
+
+## Translation keys
+
+Content in multiple languages is connected via the `translationKey` frontmatter field.
+
+```yaml
+---
+title: "Getting Started with Bitcoin"
+translationKey: "getting-started-with-bitcoin"
+lang: en
+---
+```
+
+```yaml
+---
+title: "Comenzando con Bitcoin"
+translationKey: "getting-started-with-bitcoin"
+lang: es
+---
+```
+
+The `content-linker` agent uses this to avoid linking a Spanish article to an English one when a Spanish version exists. The `/translate` skill sets `translationKey` automatically.
+
+---
+
+## Why file-based?
+
+Most RAG systems use embeddings and vector search for content discovery. content-ops deliberately avoids this because:
+
+- **No setup friction** — no vector DB to install or manage
+- **No API dependency** — the knowledge layer works offline and without external services
+- **Transparent** — every piece of knowledge Claude uses is a file you can read and edit
+- **Git-native** — the entire knowledge layer is version-controlled alongside your content
+- **Fast enough** — for typical blog-scale content (hundreds of articles), filtering + a single LLM ranking pass is faster than a round-trip to an embedding service
+
+The trade-off: at very large scale (thousands of articles), a more sophisticated retrieval system would outperform. For a blog, this approach is simpler, cheaper, and easier to debug.

--- a/content-ops/docs/skills.md
+++ b/content-ops/docs/skills.md
@@ -1,0 +1,173 @@
+# Skills
+
+Skills are the commands you type inside Claude Code. content-ops provides seven user-facing skills and five internal skills that load automatically.
+
+---
+
+## /init
+
+Setup wizard. Creates and verifies your `.content-ops/config.md` and bootstrap files.
+
+**Usage:**
+```
+/init                    → Show setup status dashboard
+/init project            → Configure author and languages
+/init content-types      → Define content types, paths, word ranges
+/init style              → Style guide and reference articles
+/init strategy           → Content strategy and pillars
+/init infra              → Create backlog, trackers, localization guides
+/init images             → Configure image generation (optional)
+```
+
+**Status dashboard** — running `/init` with no arguments shows completion status per round:
+
+```
+✅ project        author + languages set
+✅ content-types  1 type configured
+⬜ style          no reference content set
+⬜ strategy       strategy file missing
+✅ infra          backlog and tracker exist
+⬜ images         not configured
+```
+
+Run rounds in any order. Each round reads the current config state and asks only what's missing or needs updating.
+
+---
+
+## /write-content
+
+The main skill. Runs the full pipeline: research → draft → style review → glossary → linking → commit.
+
+**Usage:**
+```
+/write-content article "Getting Started with Docker"   → Interactive mode, single article
+/write-content glossary "container, image, volume"     → Create multiple glossary entries
+/write-content backlog 3                               → Autonomous: write next 3 backlog items
+/write-content backlog #1,#3,#5                        → Write specific backlog items by number
+/write-content backlog all                             → Write all pending backlog items
+/write-content                                         → Ask what to create
+```
+
+**Interactive mode** — for `article` and `glossary`, Claude asks a few questions before drafting (angle, target audience, key points to cover). The rest of the pipeline runs automatically.
+
+**Backlog mode** — runs autonomously. Each item gets its own git commit. If interrupted, completed items are preserved.
+
+**What the pipeline does:**
+1. Parse your arguments and load config
+2. Plan the topic (questions in interactive mode, or parse backlog item)
+3. Research with cache — check research cache, run web search if stale or missing
+4. Draft the content
+5. Generate images (if configured)
+6. Review and enforce style
+7. Scan for glossary terms that need entries
+8. Add bidirectional internal links
+9. Reindex and commit
+
+---
+
+## /translate
+
+Localizes existing content to a target language, respecting your localization guide for that language.
+
+**Usage:**
+```
+/translate es              → Translate all untranslated content to Spanish
+/translate de 3            → Translate next 3 articles to German
+/translate pt backlog      → Translate items flagged in the translation tracker
+```
+
+**What it does:**
+- Reads the localization guide for the target language (from `localization_guides_path`)
+- Translates content while preserving frontmatter structure and internal links
+- Updates the translation tracker
+- Links translated articles to originals via `translationKey`
+
+---
+
+## /fact-check
+
+Verifies every factual claim in a content file against trusted sources.
+
+**Usage:**
+```
+/fact-check src/content/articles/en/my-article.md
+```
+
+**What it does:**
+- Extracts all claims from the article
+- Runs web research on each claim
+- Flags anything that can't be verified or appears inaccurate
+- Returns a report — does not edit the file directly
+
+---
+
+## /review-content
+
+Full editorial review: tone, style, structure, and linking completeness.
+
+**Usage:**
+```
+/review-content src/content/articles/en/my-article.md
+```
+
+**What it checks:**
+- Sentence length (hard limit: ~25 words)
+- Paragraph length (target: 3-4 sentences)
+- Plain language (readable by a general audience)
+- H2 structure (2-4 sections, no H3)
+- Glossary term coverage (first mentions linked)
+- Internal link coverage (related articles linked)
+- Scope — if a concept gets 2+ sentences, it should probably be its own article
+
+Returns a structured report with specific suggestions.
+
+---
+
+## /suggest-content
+
+Analyzes your content strategy, pillars, and existing index to recommend what to write next.
+
+**Usage:**
+```
+/suggest-content               → 5 suggestions
+/suggest-content 10            → 10 suggestions
+/suggest-content 5 technical   → 5 suggestions filtered by theme
+```
+
+**What it does:**
+- Reads your strategy file and pillar files
+- Reads the content index (via `content-inventory` skill)
+- Identifies gaps — topics in your strategy not yet covered
+- Returns ranked suggestions with rationale
+
+---
+
+## /reindex
+
+Rebuilds the content index by scanning your content directories.
+
+**Usage:**
+```
+/reindex
+```
+
+**What it does:**
+- Scans all directories defined in `content_types`
+- Reads frontmatter from each file
+- Writes `.content-ops/content-index.json`
+
+Safe to run multiple times — always overwrites with the current state. Run it after adding, renaming, or deleting content files manually.
+
+---
+
+## Internal skills (auto-loaded)
+
+These load automatically when needed. You don't invoke them directly.
+
+| Skill | What it provides |
+|---|---|
+| `content-style` | Voice, tone, sentence rules, structure guidelines loaded by style-enforcer and draft-writer |
+| `content-image-style` | Image prompt patterns, file naming, alt text conventions loaded by image-generator |
+| `content-inventory` | Current snapshot of all articles and glossary entries, used by suggest-content and content-linker |
+| `internal-linking` | Bidirectional linking conventions loaded by content-linker |
+| `update-trackers` | Logic for updating backlog and translation tracker after write or translate |


### PR DESCRIPTION
## Summary

Completely restructured the README to be more user-focused and beginner-friendly, and added four new documentation files that break down the plugin's architecture, configuration, and operation into digestible guides.

## Key changes

- **README overhaul**: Replaced technical specification format with a narrative-driven guide that leads with what the plugin does, quick-start instructions, and a visual pipeline diagram. Moved detailed reference material to dedicated docs.

- **New documentation structure**:
  - `docs/skills.md` — Complete reference for all 7 user-facing skills and 5 internal skills, with usage examples and behavior descriptions
  - `docs/configuration.md` — Full schema reference, field descriptions, and `.content-ops/` directory layout
  - `docs/how-it-works.md` — Phase-based pipeline explanation, agent responsibilities, and file flow overview
  - `docs/knowledge-layer.md` — Deep dive into the file-based knowledge system (content index, research cache, translation keys)
  - `docs/agents.md` — Individual agent documentation with inputs, outputs, and behavior

- **Improved navigation**: README now points to specific docs for detailed topics rather than trying to cover everything inline

- **Clearer positioning**: Added "work in progress" notice and repositioned the plugin as a team of AI writers rather than a generic content tool

## Notable details

- Maintained all technical accuracy while improving readability
- Preserved all configuration examples and field references
- Added visual mermaid diagram showing the write-content pipeline
- Organized skills by invocation pattern (user-facing vs. auto-loaded)
- Documented the two-step linking approach (filter → rank → edit) to explain scalability
- Clarified the research cache TTL behavior and git portability

https://claude.ai/code/session_0173pVQJvWBi5S9tEFQkuUto