### PR TITLE
fix: move style guide paths from docs/ to .content-ops/

### DIFF
--- a/content-ops/config.example.md
+++ b/content-ops/config.example.md
@@ -15,7 +15,7 @@ content_base_path: "src/content"
 content_types:
   article:
     path: "src/content/articles"
-    guidelines: "docs/content-style-guide.md"
+    guidelines: ".content-ops/content-style-guide.md"
     word_range: [800, 1500]
     frontmatter:
       - title
@@ -30,7 +30,7 @@ content_types:
 
   glossary:
     path: "src/content/glossary"
-    guidelines: "docs/content-style-guide.md"
+    guidelines: ".content-ops/content-style-guide.md"
     word_range: [50, 150]
     frontmatter:
       - term
@@ -74,7 +74,7 @@ research_cache_ttl_days: 30
 #   enabled: true
 #   provider: "google-gemini"        # google-gemini | openai-gpt-image | manual
 #   model: ""                        # optional — omit for provider default (imagen-3.0-generate-002 / gpt-image-1)
-#   guidelines: "docs/image-style-guide.md"
+#   guidelines: ".content-ops/image-style-guide.md"
 #   output_path: "public/images"
 #   hero_dimensions: [1200, 630]
 #   inline_dimensions: [800, 450]

--- a/content-ops/skills/content-image-style/SKILL.md
+++ b/content-ops/skills/content-image-style/SKILL.md
@@ -18,7 +18,7 @@ The following `image_generation` values are expected in your task prompt from th
 - `image_generation.placement`, `image_generation.min_word_count`, `image_generation.skip_types`
 - `image_generation.max_inline_images` (optional — caps inline images per article)
 
-For the full image style guide, read the file at `image_generation.guidelines` (e.g., `docs/image-style-guide.md`). Below is the condensed reference for quick access.
+For the full image style guide, read the file at `image_generation.guidelines` (e.g., `.content-ops/image-style-guide.md`). Below is the condensed reference for quick access.
 
 ## Pre-Flight Checks
 

--- a/content-ops/skills/init/rounds/content-types.md
+++ b/content-ops/skills/init/rounds/content-types.md
@@ -96,7 +96,7 @@ If D: ask for min and max as free text.
 
 ```text
 Which style guide covers [type name] content?
-  A — Shared project style guide (docs/content-style-guide.md)
+  A — Shared project style guide (.content-ops/content-style-guide.md)
   B — Its own separate guidelines file (I'll specify the path)
   C — No guidelines file yet — set up in /init style
 ```

--- a/content-ops/skills/init/rounds/images.md
+++ b/content-ops/skills/init/rounds/images.md
@@ -186,7 +186,7 @@ If **Custom path**: the user types their path via the Other/free-text input.
 
 ## Phase 3: Create image style guide
 
-Using the answers from Phase 2, create the image style guide at the path that will be set in config (default `docs/image-style-guide.md`).
+Using the answers from Phase 2, create the image style guide at the path that will be set in config (default `.content-ops/image-style-guide.md`).
 
 The guide must be **actionable** — it is read verbatim by the `image-generator` agent to build image prompts and make placement decisions.
 

--- a/content-ops/skills/init/rounds/infra.md
+++ b/content-ops/skills/init/rounds/infra.md
@@ -170,7 +170,7 @@ You're ready:
   /fact-check [file]                    — verify claims in an article
 
 Config: .content-ops/config.md
-Docs:    docs/content-style-guide.md
+Docs:    .content-ops/content-style-guide.md
          .content-ops/strategy.md
          .content-ops/pillars/
 ```

--- a/content-ops/skills/init/rounds/style.md
+++ b/content-ops/skills/init/rounds/style.md
@@ -12,7 +12,7 @@ Read `.content-ops/config.md`. Extract:
 - `reference_content` — existing reference files
 - The project description comment (line starting with `#` above the `author` field)
 
-Check if a style guide already exists: look at `guidelines` paths in `content_types`, and also check `docs/content-style-guide.md` directly.
+Check if a style guide already exists: look at `guidelines` paths in `content_types`, and also check `.content-ops/content-style-guide.md` directly.
 
 **If a style guide already exists:**
 
@@ -153,7 +153,7 @@ Drop a URL, a file path, or just describe it.
 
 ## Phase 4: Generate style guide
 
-Using the answers from Phase 3 and the signals from Phase 2, create `docs/content-style-guide.md`.
+Using the answers from Phase 3 and the signals from Phase 2, create `.content-ops/content-style-guide.md`.
 
 The guide must be **concrete and specific** — generic style guides are useless. Every rule needs an example.
 
@@ -207,7 +207,7 @@ Use the paragraph exercise from Question 3:
 
 Update `.content-ops/config.md`:
 
-- For each content type in `content_types` that does not already have a type-specific `guidelines` file, set `guidelines: "docs/content-style-guide.md"`
+- For each content type in `content_types` that does not already have a type-specific `guidelines` file, set `guidelines: ".content-ops/content-style-guide.md"`
 - Set `reference_content` to 2–3 of the most representative existing files found during Phase 2 scanning
 
 Preserve all other fields.
@@ -217,7 +217,7 @@ Preserve all other fields.
 ## Phase 6: Confirm and guide
 
 ```text
-✅ Style guide created at docs/content-style-guide.md
+✅ Style guide created at .content-ops/content-style-guide.md
 
 Voice summary:
   • [characteristic 1 from the guide]


### PR DESCRIPTION
Update all references to content-style-guide.md and image-style-guide.md
across config, init rounds, and skill files to use .content-ops/ instead
of docs/, consistent with the plugin's design principle that all
plugin-managed files live under .content-ops/.

Fixes #12

https://claude.ai/code/session_01V7pr5o18UNGSk8hQpSfQed