### PR TITLE
fix(content-image-gemini): fix non-interactive dependency installation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,7 +17,7 @@
     {
       "name": "content-image-gemini",
       "description": "AI image generation for content using the Gemini CLI and Nano Banana extension. Headless-friendly: auto-installs dependencies on first use.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "pcamarajr"
       },

--- a/content-image-gemini/README.md
+++ b/content-image-gemini/README.md
@@ -5,10 +5,10 @@ AI image generation using the [Gemini CLI](https://github.com/google-gemini/gemi
 ## Prerequisites
 
 - **Node.js** — required to install the Gemini CLI via `npm`
-- **`NANOBANANA_API_KEY`** — a Gemini API key from [Google AI Studio](https://aistudio.google.com)
+- **`GEMINI_API_KEY`** — a Gemini API key from [Google AI Studio](https://aistudio.google.com)
 
 ```bash
-export NANOBANANA_API_KEY="your-api-key-here"
+export GEMINI_API_KEY="your-api-key-here"
 ```
 
 ## Usage

--- a/content-image-gemini/agents/image-generator.md
+++ b/content-image-gemini/agents/image-generator.md
@@ -37,32 +37,25 @@ tools: ["Bash"]
 You are a thin image generation executor. You run Gemini CLI commands and report results. You do not build prompts, infer content, or make creative decisions — those are the caller's responsibility.
 
 **Contract:**
+
 - Input: a ready-made `prompt` string, optional `aspect` (default `16:9`), optional `count` (default `1`)
 - Output: the path(s) of the generated file(s) in `./nanobanana-output/`
 
 **Steps:**
 
-1. **Check API key** — without printing it:
-   ```bash
-   test -n "${NANOBANANA_API_KEY}" && echo "set" || echo "missing"
-   ```
-   If missing, stop: `Error: NANOBANANA_API_KEY is not set. Export it before running image generation.`
-
-2. **Choose the command** based on the prompt subject:
+1. **Choose the command** based on the prompt subject:
    - Diagram, flowchart, architecture → `/diagram`
    - Icon, favicon → `/icon`
    - Everything else → `/generate`
 
-3. **Run the CLI:**
+2. **Run the CLI:**
+
    ```bash
    gemini --yolo "/generate 'PROMPT' --aspect=ASPECT --count=COUNT"
    ```
+
    Replace `/generate` with `/diagram` or `/icon` if appropriate. Use the prompt exactly as given — do not modify it.
 
-4. **Report** the full path(s) of every file written to `./nanobanana-output/`.
+3. **Report** the full path(s) of every file written to `./nanobanana-output/`.
 
 **If no prompt is provided:** ask for one. Do not guess.
-
-**If the CLI is missing:** tell the user to run `npm install -g @google/gemini-cli`.
-
-**If the nanobanana extension is missing:** tell the user to run `gemini extensions install https://github.com/gemini-cli-extensions/nanobanana`.

--- a/content-image-gemini/hooks/scripts/ensure-deps.sh
+++ b/content-image-gemini/hooks/scripts/ensure-deps.sh
@@ -5,23 +5,30 @@ set -euo pipefail
 input=$(cat)
 cmd=$(echo "$input" | jq -r '.tool_input.command // ""')
 
-# Only run when a gemini command is about to execute
-if [[ "$cmd" != *"gemini"* ]]; then
-  exit 0
+# Only run for commands that invoke the gemini CLI
+[[ "$cmd" == *"gemini"* ]] || exit 0
+
+# Validate API key
+if [[ -z "${GEMINI_API_KEY:-}" ]]; then
+  echo "content-image-gemini: GEMINI_API_KEY is not set. Export it before running image generation." >&2
+  exit 2
 fi
 
 # Install Gemini CLI if missing
 if ! command -v gemini &>/dev/null; then
   echo "content-image-gemini: Installing @google/gemini-cli..." >&2
-  npm install -g @google/gemini-cli >&2
+  npm install -g @google/gemini-cli >/dev/null 2>&1
 fi
 
-# Install nanobanana extension if missing
-# Capture output first to avoid pipefail exiting on a non-zero gemini extensions list
-installed_extensions=$(gemini extensions list 2>/dev/null || echo "")
-if ! echo "$installed_extensions" | grep -q "nanobanana"; then
+# Clean stale nanobanana dir and reinstall if missing or incomplete
+NANOBANANA_DIR="${HOME}/.gemini/extensions/nanobanana"
+NANOBANANA_CONFIG="${NANOBANANA_DIR}/gemini-extension.json"
+if [[ -d "$NANOBANANA_DIR" && ! -f "$NANOBANANA_CONFIG" ]]; then
+  rm -rf "$NANOBANANA_DIR"
+fi
+if [[ ! -f "$NANOBANANA_CONFIG" ]]; then
   echo "content-image-gemini: Installing nanobanana extension..." >&2
-  gemini extensions install https://github.com/gemini-cli-extensions/nanobanana >&2
+  gemini extensions install https://github.com/gemini-cli-extensions/nanobanana --consent >/dev/null 2>&1
 fi
 
 exit 0


### PR DESCRIPTION
## Summary

- Hook exits early for non-gemini Bash commands (avoids unnecessary work on every tool call)
- `GEMINI_API_KEY` validated in hook with `exit 2` — blocks execution before agent runs anything
- `gemini extensions install` now uses `--consent` flag for non-interactive environments
- Presence check uses `gemini-extension.json` instead of just the directory — detects incomplete installs
- Stale/incomplete extension directories are auto-cleaned before reinstalling
- All pre-flight checks moved from agent to hook — agent is now a pure prompt executor (3 steps)
- Renamed `NANOBANANA_API_KEY` → `GEMINI_API_KEY` throughout

## Test plan

- [ ] Trigger image generation with `GEMINI_API_KEY` unset — should block with clear error
- [ ] Trigger with a stale `~/.gemini/extensions/nanobanana` dir (missing `gemini-extension.json`) — should clean and reinstall
- [ ] Trigger with clean environment — should install CLI + extension and generate image end-to-end
- [ ] Trigger non-image Bash commands — hook should exit immediately without running any checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)