### PR TITLE
feat(astro-builder): audit orchestrator + css-conventions mechanical checks (v1.4.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,8 @@
 {
   "name": "content-stack",
   "owner": {
-    "name": "pcamarajr"
+    "name": "pcamarajr",
+    "email": "eu@pcamarajr.dev"
   },
   "plugins": [
     {
@@ -9,7 +10,8 @@
       "description": "Content creation and management plugin for static site blogs. Handles writing, translation, research, linking, style review, and knowledge indexing.",
       "version": "0.7.0",
       "author": {
-        "name": "pcamarajr"
+        "name": "pcamarajr",
+        "email": "eu@pcamarajr.dev"
       },
       "source": "./content-ops",
       "category": "content"
@@ -19,7 +21,8 @@
       "description": "AI image generation for content using the Gemini CLI and Nano Banana extension. Headless-friendly: auto-installs dependencies on first use.",
       "version": "1.0.0",
       "author": {
-        "name": "pcamarajr"
+        "name": "pcamarajr",
+        "email": "eu@pcamarajr.dev"
       },
       "source": "./content-image-gemini",
       "category": "content"
@@ -29,7 +32,8 @@
       "description": "Build Astro 6 static content sites with Claude. Enforces best practices for i18n, content collections, the page-views pattern, and design systems. Starts with /astro-builder:init to configure your project.",
       "version": "1.3.0",
       "author": {
-        "name": "pcamarajr"
+        "name": "pcamarajr",
+        "email": "eu@pcamarajr.dev"
       },
       "source": "./astro-builder",
       "category": "development"
@@ -39,7 +43,8 @@
       "description": "Site-level SEO intelligence layer for static content sites. Powered by Google Search Console — tracks performance, surfaces ranking opportunities, diagnoses pages with live data, and injects keyword briefs into the content creation pipeline.",
       "version": "2.0.0",
       "author": {
-        "name": "pcamarajr"
+        "name": "pcamarajr",
+        "email": "eu@pcamarajr.dev"
       },
       "source": "./content-seo",
       "category": "content"
@@ -49,7 +54,8 @@
       "description": "Track Claude Code token usage and estimated API cost per session, including subagent runs. Logs are scoped to the project and stored in .cost-log/.",
       "version": "0.3.0",
       "author": {
-        "name": "pcamarajr"
+        "name": "pcamarajr",
+        "email": "eu@pcamarajr.dev"
       },
       "source": "./cost-tracker",
       "category": "developer-tools"
@@ -59,7 +65,8 @@
       "description": "Astro language server for code intelligence, diagnostics, and formatting in .astro files",
       "version": "1.0.1",
       "author": {
-        "name": "pcamarajr"
+        "name": "pcamarajr",
+        "email": "eu@pcamarajr.dev"
       },
       "source": "./astro-lsp",
       "category": "development",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,7 +30,7 @@
     {
       "name": "astro-builder",
       "description": "Build Astro 6 static content sites with Claude. Enforces best practices for i18n, content collections, the page-views pattern, and design systems. Starts with /astro-builder:init to configure your project.",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "author": {
         "name": "pcamarajr",
         "email": "eu@pcamarajr.dev"

--- a/astro-builder/.claude-plugin/plugin.json
+++ b/astro-builder/.claude-plugin/plugin.json
@@ -2,7 +2,8 @@
   "name": "astro-builder",
   "description": "Build Astro 6 static content sites with Claude. Enforces best practices for i18n, content collections, the page-views pattern, and design systems. Starts with /astro-builder:init to configure your project.",
   "author": {
-    "name": "pcamarajr"
+    "name": "pcamarajr",
+    "email": "eu@pcamarajr.dev"
   },
   "homepage": "https://github.com/pcamarajr/content-stack",
   "repository": "https://github.com/pcamarajr/content-stack",

--- a/astro-builder/README.md
+++ b/astro-builder/README.md
@@ -48,7 +48,7 @@ If you want the fastest start, begin from the ready template:
 | `/astro-builder:new-page` | Scaffold a page + page-view pair for all locales |
 | `/astro-builder:new-content-type` | Add a new content collection with schema, utilities, and example content |
 | `/astro-builder:translate` | Localize a content entry or i18n JSON to another locale |
-| `/astro-builder:audit` | Audit for anti-patterns, AI design slop, missing translations, schema errors, and build failures |
+| `/astro-builder:audit` | Orchestrated project audit: architecture, i18n, schema, per-skill domain checklists (CSS today), AI design slop, style guide, and build validation |
 | `css-conventions` _(auto-applied)_ | Enforces CSS discipline whenever styles are written: token-only values, scoped `<style>` blocks, Tier-1 modern CSS, no Tailwind / CSS-in-JS / preprocessors, and a CSS-first interactivity ladder |
 | `ux-writing` _(auto-applied)_ | Enforces clear interface copy whenever a user-facing string is written: verb+object button labels, the error-message formula, empty/loading/success states, and i18n-first string placement |
 

--- a/astro-builder/skills/audit/SKILL.md
+++ b/astro-builder/skills/audit/SKILL.md
@@ -1,10 +1,23 @@
 ---
-description: Audit the Astro 6 project for anti-patterns, missing translations, broken internal links, style guide violations, and schema inconsistencies. Produces a prioritized report with actionable fixes.
+description: >
+  Audit an astro-builder project end to end and produce a prioritized, actionable report. Trigger
+  when the user runs /astro-builder:audit, asks to "audit the site", "check for anti-patterns",
+  "find what's broken", "review the project for quality issues", or before a release / after a
+  large refactor / after onboarding an existing Astro repo. Covers architecture (page-views,
+  config locations), i18n completeness, content schema validity, every convention-skill domain
+  checklist (CSS today; more as skills ship), anti-slop design review, style guide adherence, and
+  build validation.
 ---
 
 # /astro-builder:audit
 
-You are auditing this Astro 6 project for quality issues. Run a thorough inspection across four categories, then produce a prioritized report.
+You are auditing this Astro 6 project for quality issues across every domain the plugin enforces.
+
+**Why this shape:** the audit is a thin orchestrator. Each convention skill owns its rules in its
+`SKILL.md` and the mechanical checks for those rules in its `references/audit.md` — the rule and
+its check live together, and the audit never restates them. Adding a new domain to the audit costs
+one line in the Domain checklists table. The steps below that have no backing skill (architecture,
+i18n, schema, style guide, build) are the audit's own.
 
 ## Step 1 — Load project context
 
@@ -13,15 +26,15 @@ Read:
 2. `.astro-builder/anti-patterns.md` — project-specific anti-patterns.
 3. `.astro-builder/content-schema.md` — expected content structure.
 4. `.astro-builder/style-guide.md` — writing rules.
-5. `.astro-builder/design-system.md` — token namespaces.
+5. `.astro-builder/design-system.md` — token namespaces and register.
 6. `src/styles/global.css` — token source of truth.
 7. `astro.config.ts` — i18n config, integrations, adapter.
 8. `src/content.config.ts` — collection schemas.
 
 Also read, from the plugin root:
 - `docs/astro-patterns.md` — canonical Astro 6 anti-patterns.
-- `docs/anti-slop.md` — the anti-slop / design-quality rule catalog (used in Step 4.6).
-- `docs/registers.md` — the brand vs. product register model that scopes Step 4.6 severity.
+- `docs/anti-slop.md` — the anti-slop / design-quality rule catalog (used in Step 6).
+- `docs/registers.md` — the brand vs. product register model that scopes Step 6 severity.
 
 ## Step 2 — Architecture audit
 
@@ -50,28 +63,23 @@ For each content collection defined in `src/content.config.ts`:
 - Check that `tags` are arrays (not strings).
 - Flag any files with frontmatter errors.
 
-## Step 4.5 — CSS conventions audit
+## Step 5 — Domain checklists
 
-Read `.astro-builder/design-system.md` to learn the project's token names. Then sweep the codebase for `css-conventions` skill violations. Report findings as P1 unless noted.
+Each convention skill ships its mechanical checks in `references/audit.md`. For every row in the
+table below, read the checklist file (path relative to the plugin root) and run every check in it.
 
-Run these greps (adjust shell-globbing as needed):
+| Domain | Checklist |
+|---|---|
+| CSS conventions | `skills/css-conventions/references/audit.md` |
 
-| Violation | Pattern | Severity |
-|---|---|---|
-| `!important` used | `grep -rn "!important" src --include="*.astro" --include="*.css"`. Allowed only inside `@media (prefers-reduced-motion: reduce)` blocks. | P1 |
-| Tailwind / utility framework | `grep -rn -E "@tailwind\|@apply\|tailwindcss" src package.json` | P0 |
-| CSS-in-JS or preprocessor | `grep -rn -E "styled-components\|@emotion\|sass\|less\|stylus" package.json` | P0 |
-| CSS Modules / sibling .css | find files matching `**/*.module.css` or component-named `.css` siblings | P1 |
-| `<style is:global>` in component | `grep -rn "style is:global" src --include="*.astro"` (outside `src/layouts/BaseLayout.astro` if used to import global.css) | P1 |
-| Inline `style=` with standard properties | `grep -rnE "style=\"[^\"]*[a-z-]+:" src --include="*.astro"`. Only custom-property assignments (`style="--x: ..."`) are allowed. | P1 |
-| Raw hex colors outside global.css | `grep -rn -E "#[0-9a-fA-F]{3,8}" src --include="*.astro"` — flag any in `<style>` blocks. | P1 |
-| Raw `rgb(` / `rgba(` / `hsl(` outside global.css | `grep -rn -E "rgba?\(\|hsla?\(" src --include="*.astro"` in `<style>` blocks | P1 |
-| ID selectors for styling | `grep -rn -E "^\s*#[a-z]" src --include="*.astro"` in `<style>` blocks | P2 |
-| Nesting deeper than 2 levels | manual inspection of any `<style>` block flagged by the file scan | P2 |
+Contract (defined once here, honored by every checklist):
+- A grep hit is a **candidate**, not a verdict — confirm against the rule's intent and documented
+  exceptions before reporting.
+- Report each confirmed finding with `file:line`, the offending fragment, the check's severity,
+  and its suggested fix, grouped under a per-domain subsection of the report.
+- To add a new domain to the audit, add one row to this table — nothing else.
 
-For each violation, link to the specific file:line and quote the offending fragment in the report.
-
-## Step 4.6 — Anti-slop & design-quality audit
+## Step 6 — Anti-slop & design-quality audit
 
 Detect AI-generated design tells ("slop") and design-quality defects. Read the full rule catalog at
 `docs/anti-slop.md` (relative to plugin root) — it defines ~40 rules in three categories (`slop`,
@@ -94,9 +102,7 @@ Detect AI-generated design tells ("slop") and design-quality defects. Read the f
 Report findings under a dedicated **Anti-slop** subsection of the report, each with file:line, the
 offending fragment, the rule id, and the concrete fix from the catalog.
 
----
-
-## Step 5 — Style guide audit
+## Step 7 — Style guide audit
 
 Read `.astro-builder/style-guide.md` and check a sample of 5 content files per collection:
 - Does the tone match the defined voice?
@@ -105,13 +111,13 @@ Read `.astro-builder/style-guide.md` and check a sample of 5 content files per c
 
 This is a best-effort check — report findings but don't auto-fix style issues.
 
-## Step 6 — Build validation
+## Step 8 — Build validation
 
 Run `pnpm build`. If it fails, include the full error output in the report as a P0 issue.
 Run `tsc --noEmit`. Include any TypeScript errors as P0 issues.
 Run `biome check .` if Biome is configured. Include lint errors as P1 issues.
 
-## Step 7 — Report
+## Step 9 — Report
 
 Produce a structured report in this format:
 
@@ -133,6 +139,14 @@ Produce a structured report in this format:
 - Build status: PASS / FAIL
 ```
 
+Before presenting the report, verify:
+
+- [ ] Every domain checklist in the Step 5 table was read and fully run.
+- [ ] Every finding has `file:line`, the offending fragment, and a concrete fix.
+- [ ] Every grep candidate was confirmed against its rule's intent — no raw hits reported.
+- [ ] Anti-slop severities reflect the resolved register.
+- [ ] Build, TypeScript, and lint results are reflected in the P0/P1 sections.
+
 After presenting the report, ask: "Would you like me to fix all P0 and P1 issues automatically?"
 
 If yes, fix them autonomously, then re-run `pnpm build` and `tsc --noEmit` to confirm all P0/P1 issues are resolved.
@@ -141,4 +155,6 @@ If yes, fix them autonomously, then re-run `pnpm build` and `tsc --noEmit` to co
 
 - Never auto-fix P2 style issues without asking.
 - Never modify content body text during the audit without explicit instruction.
+- Never restate a convention skill's rules here — rules live in each skill's `SKILL.md`, checks in
+  its `references/audit.md`. This file only orchestrates.
 - Always follow the Astro 6 documentation: https://docs.astro.build/llms-small.txt

--- a/astro-builder/skills/css-conventions/SKILL.md
+++ b/astro-builder/skills/css-conventions/SKILL.md
@@ -16,6 +16,14 @@ The single source of truth for how CSS is authored in an astro-builder project. 
 CSS is written, reviewed, or refactored. Six disciplines, one modern-features checklist, one
 interactivity ladder.
 
+**Why these rules exist:** the platform already ships everything utility frameworks, preprocessors,
+and CSS-in-JS were invented to patch — `@layer`, nesting, `color-mix()`, container queries, custom
+properties. Tokens in one file plus Astro-scoped `<style>` blocks keep every visual decision
+traceable to a single source of truth, so a design change is a token edit, not a codebase sweep.
+Anything that hides the cascade (a build step, inline styles, `!important`) makes the next change
+more expensive. The mechanical checks for these rules live in `references/audit.md` — the audit
+runs them; this file is where the rules are defined.
+
 ---
 
 ## Step 1 — Resolve the project's browser tier
@@ -31,7 +39,7 @@ Map to tier:
 
 | Tier | Resolves to roughly | Stance |
 |------|---------------------|--------|
-| **Tier 1** (default) | Chrome 125+ / Safari 17.5+ / Firefox 128+ | Use everything stable. Two mandatory fallbacks (Step 4). |
+| **Tier 1** (default) | Chrome 125+ / Safari 17.5+ / Firefox 128+ | Use everything stable. Two mandatory fallbacks (Step 3). |
 | **Tier 2** | Chrome 111+ / Safari 16.4+ / Firefox 113+ | Use most modern features. Wrap `field-sizing`, `@scope`, `@starting-style`, `transition-behavior: allow-discrete`, scroll-driven animations, `:popover-open` in `@supports`. |
 | **Tier 3** | Chrome 105+ / Safari 15+ / Firefox 110+ | Be selective. Wrap OKLCH, `color-mix`, `:has()`, container queries, `@layer` in `@supports`. |
 
@@ -143,7 +151,7 @@ project's tier are free to use; items above require an `@supports` wrapper or a 
 - [ ] **OKLCH** for color definitions — *Tier 2+*
 - [ ] **`color-mix()`** for tints/shades/opacity variants — *Tier 2+*
 - [ ] **Relative color syntax** (`oklch(from var(--c) l c h)`) — *Tier 1+*
-- [ ] **`light-dark()`** — *Tier 1, with mandatory fallback (Step 4)*
+- [ ] **`light-dark()`** — *Tier 1, with mandatory fallback (Step 3)*
 - [ ] **`accent-color`** for native form controls — *Tier 2+*
 
 #### Layout & sizing
@@ -183,7 +191,7 @@ project's tier are free to use; items above require an `@supports` wrapper or a 
 - [ ] **`inset` shorthand** instead of top/right/bottom/left longhand — *Tier 2+*
 - [ ] **Logical properties** (`margin-inline`, `padding-block`) for i18n-ready layouts — *Tier 2+*
 - [ ] **`scroll-margin` / `scroll-padding`** for sticky-header anchor offsets — *Tier 2+*
-- [ ] **Anchor positioning** for tooltips / popovers / dropdowns — *Tier 1, non-critical UI only (Step 4)*
+- [ ] **Anchor positioning** for tooltips / popovers / dropdowns — *Tier 1, non-critical UI only (Step 3)*
 
 #### Visual effects
 - [ ] **`backdrop-filter`** for frosted glass / blur overlays — *Tier 2+*
@@ -317,8 +325,29 @@ Load these on demand for exact syntax, browser version floors, and `@supports` p
 - `references/positioning.md` — anchor positioning, logical properties, `scroll-margin`
 - `references/misc.md` — `@property`, `content-visibility`, popover, `backdrop-filter`, blend modes, `clip-path`
 - `references/components.md` — `accent-color`, `env()`, media features, scrollbar, `margin-trim`, scroll-snap
+- `references/audit.md` — the mechanical checks (greps + inspections) for this skill's rules, run
+  by `/astro-builder:audit`. When a rule in this file changes, update its check there.
 
 Load only the file relevant to the feature you're using. Do not load all references at once.
+
+---
+
+## Step 6 — Verify before finishing
+
+After writing or refactoring any CSS, confirm:
+
+- [ ] Every color, font, size, spacing, radius, and shadow value is a token (or a documented
+      allowed raw value — Step 2.1).
+- [ ] New tokens were added to `global.css` first and documented in
+      `.astro-builder/design-system.md`.
+- [ ] All component CSS lives in the component's single `<style>` block — no new `.css` files,
+      no `is:global`, no inline standard properties.
+- [ ] Class names are semantic kebab-case — no utility names, no BEM.
+- [ ] No `!important`, no ID selectors, nesting ≤2 levels.
+- [ ] Features above the project's tier are wrapped in `@supports`; the two mandatory fallbacks
+      (Step 3) are in place if `light-dark()` or anchor positioning is used.
+- [ ] If interactivity was added, the ladder (Step 4) was walked — JS only where CSS could not
+      express the behavior.
 
 ---
 

--- a/astro-builder/skills/css-conventions/references/audit.md
+++ b/astro-builder/skills/css-conventions/references/audit.md
@@ -1,0 +1,152 @@
+# CSS conventions — mechanical audit checklist
+
+The machine-runnable checks for the `css-conventions` skill. `SKILL.md` is the source of every
+rule; this file only encodes *how to detect* violations of those rules. `/astro-builder:audit`
+runs this checklist as the CSS entry in its domain-checklist step — keep the two in sync by
+editing the rule in `SKILL.md` first, then its check here.
+
+**Contract for every check below:** a grep hit is a *candidate*, not a verdict. Confirm each hit
+against the rule's intent (and its documented exceptions) before reporting. Report confirmed
+findings with `file:line`, the offending fragment, and the suggested fix.
+
+Before running: read `.astro-builder/design-system.md` to learn the project's token names, and
+`src/styles/global.css` to know which values are tokens.
+
+---
+
+## CSS-1 — `!important`
+
+- **Rule:** `!important` is forbidden; cascade fights are solved by `@layer` order (SKILL.md §2.4).
+- **Severity:** P1
+- **Detect:** `grep -rn "!important" src --include="*.astro" --include="*.css"`
+- **Confirm:** allowed only inside `@media (prefers-reduced-motion: reduce)` blocks. Anything
+  else is a violation.
+- **Fix:** remove `!important`; adjust `@layer` order in `global.css` or lower the competing
+  selector's specificity with `:where()`.
+
+## CSS-2 — Tailwind / utility-class framework
+
+- **Rule:** utility-class frameworks are forbidden (SKILL.md §2.5).
+- **Severity:** P0
+- **Detect:** `grep -rn -E "@tailwind|@apply|tailwindcss" src package.json`
+- **Confirm:** any hit in source or dependencies is a violation; a mention inside a comment or
+  docs file is not.
+- **Fix:** remove the dependency and rewrite utility classes as semantic classes in scoped
+  `<style>` blocks using tokens.
+
+## CSS-3 — CSS-in-JS / preprocessor
+
+- **Rule:** CSS-in-JS libraries and preprocessors are forbidden (SKILL.md §2.5).
+- **Severity:** P0
+- **Detect:** `grep -rn -E "styled-components|@emotion|sass|less|stylus" package.json`
+- **Confirm:** check it is a real dependency, not a substring of an unrelated package name.
+- **Fix:** remove the dependency; express the styles in native CSS (`@layer`, nesting,
+  `color-mix()`, custom properties cover the preprocessor use cases).
+
+## CSS-4 — CSS Modules / sibling `.css` files
+
+- **Rule:** all component CSS lives in the component's `<style>` block; CSS Modules and sibling
+  `.css` files are forbidden (SKILL.md §2.2).
+- **Severity:** P1
+- **Detect:** find files matching `**/*.module.css`, and `.css` files named after a component
+  (e.g. `Card.css` next to `Card.astro`).
+- **Confirm:** `src/styles/global.css` is the one allowed stylesheet; anything else is a
+  violation.
+- **Fix:** move the rules into the component's scoped `<style>` block (or into `global.css` if
+  genuinely global) and delete the file.
+
+## CSS-5 — `<style is:global>` in components
+
+- **Rule:** if it needs to be global, it belongs in `global.css` (SKILL.md §2.2).
+- **Severity:** P1
+- **Detect:** `grep -rn "style is:global" src --include="*.astro"`
+- **Confirm:** a hit in `src/layouts/BaseLayout.astro` used purely to import `global.css` is
+  acceptable; everywhere else is a violation.
+- **Fix:** move the rules into `global.css` under the appropriate `@layer`, or drop `is:global`
+  and let Astro scope them.
+
+## CSS-6 — Inline `style=` with standard properties
+
+- **Rule:** inline styles may set CSS custom properties only, never standard properties
+  (SKILL.md §2.2).
+- **Severity:** P1
+- **Detect:** `grep -rnE "style=\"[^\"]*[a-z-]+:" src --include="*.astro"` (also check
+  `style={` expressions).
+- **Confirm:** custom-property assignments (`style="--x: ..."`, including template-literal
+  expressions that only set `--*` properties) are the allowed exception; any standard property
+  is a violation.
+- **Fix:** move the declaration into the `<style>` block; if the value is dynamic, pass it
+  through a custom property and consume it in scoped CSS.
+
+## CSS-7 — Raw hex colors outside `global.css`
+
+- **Rule:** color literals are forbidden outside `global.css` — colors come from `--color-*`
+  tokens (SKILL.md §2.1).
+- **Severity:** P1
+- **Detect:** `grep -rn -E "#[0-9a-fA-F]{3,8}" src --include="*.astro"`
+- **Confirm:** flag hits inside `<style>` blocks. Hex fragments in markup that are not colors
+  (anchors, IDs, data) are false positives.
+- **Fix:** use the matching `--color-*` token; if none exists, add one to `global.css` first and
+  document it in `.astro-builder/design-system.md`.
+
+## CSS-8 — Raw `rgb()` / `hsl()` / `oklch()` outside `global.css`
+
+- **Rule:** same token discipline as CSS-7 — functional color literals are forbidden outside
+  `global.css` (SKILL.md §2.1).
+- **Severity:** P1
+- **Detect:** `grep -rn -E "rgba?\(|hsla?\(|oklch\(" src --include="*.astro"`
+- **Confirm:** flag hits inside `<style>` blocks. `oklch(from var(--c) ...)` relative-color
+  derivations of an existing token are acceptable.
+- **Fix:** replace with a `--color-*` token (adding it to `global.css` if needed), or derive the
+  variant with `color-mix()` / relative color syntax from an existing token.
+
+## CSS-9 — ID selectors for styling
+
+- **Rule:** IDs are reserved for anchor targets and JS hooks, never styling (SKILL.md §2.4).
+- **Severity:** P2
+- **Detect:** `grep -rn -E "^\s*#[a-z]" src --include="*.astro"`
+- **Confirm:** flag hits inside `<style>` blocks; `#` occurrences in markup or scripts are false
+  positives.
+- **Fix:** replace the ID selector with a semantic class.
+
+## CSS-10 — Nesting deeper than 2 levels
+
+- **Rule:** nesting maximum 2 levels deep in scoped CSS (SKILL.md §2.4).
+- **Severity:** P2
+- **Detect:** no reliable grep — manually inspect the `<style>` blocks of any file already
+  flagged by the other checks, plus the largest components.
+- **Confirm:** `&:hover` / `& .child` is the allowed depth; a selector three levels in is a
+  violation.
+- **Fix:** flatten — Astro's scoping already isolates the component, so descendant chains add
+  specificity without adding safety.
+
+## CSS-11 — Utility-style class names
+
+- **Rule:** utility-class names (`.mt-4`, `.text-lg`, `.flex`, `.gap-2`) are forbidden; classes
+  are semantic and kebab-case (SKILL.md §2.3).
+- **Severity:** P2
+- **Detect:** `grep -rn -E "class=\"[^\"]*\b(mt|mb|mx|my|pt|pb|px|py|gap|text|font|w|h)-[0-9a-z]+\b" src --include="*.astro"`
+- **Confirm:** the pattern is noisy — confirm the class encodes a visual value rather than a
+  meaning (`.text-lg` is a violation; `.text-block` is not).
+- **Fix:** rename to a semantic class and move the visual decision into its scoped CSS rule.
+
+## CSS-12 — Universal selector outside the reset
+
+- **Rule:** `*` is only allowed in `@layer reset` (SKILL.md §2.4).
+- **Severity:** P2
+- **Detect:** `grep -rn -E "^\s*\*[ ,{:]" src --include="*.astro"` and the same pattern in
+  `global.css` outside the `@layer reset` block.
+- **Confirm:** `*, *::before, *::after` box-sizing rules inside `@layer reset` are the allowed
+  use; component-level universal selectors are violations.
+- **Fix:** target the actual elements or a shared class instead.
+
+## CSS-13 — Non-canonical token namespaces
+
+- **Rule:** tokens use the six canonical namespaces (`--color-*`, `--font-*`, `--text-*`,
+  `--space-*`, `--radius-*`, `--shadow-*`); inventing new namespaces is forbidden
+  (SKILL.md §2.1, Constraints).
+- **Severity:** P2
+- **Detect:** `grep -rn -E "^\s*--[a-z]+-" src/styles/global.css` and review the prefixes found.
+- **Confirm:** `--motion-*` is a sanctioned promotion for reused durations/easings; anything
+  else outside the six namespaces (e.g. `--ui-*`, `--page-*`) is a violation.
+- **Fix:** rename the token into the canonical namespace and update its usages.

--- a/astro-lsp/.claude-plugin/plugin.json
+++ b/astro-lsp/.claude-plugin/plugin.json
@@ -2,7 +2,8 @@
   "name": "astro-lsp",
   "description": "Astro language server for code intelligence, diagnostics, and formatting in .astro files",
   "author": {
-    "name": "pcamarajr"
+    "name": "pcamarajr",
+    "email": "eu@pcamarajr.dev"
   },
   "repository": "https://github.com/pcamarajr/content-stack",
   "license": "MIT",

--- a/content-image-gemini/.claude-plugin/plugin.json
+++ b/content-image-gemini/.claude-plugin/plugin.json
@@ -2,7 +2,8 @@
   "name": "content-image-gemini",
   "description": "AI image generation for content using the Gemini CLI and Nano Banana extension. Headless-friendly: auto-installs dependencies on first use.",
   "author": {
-    "name": "pcamarajr"
+    "name": "pcamarajr",
+    "email": "eu@pcamarajr.dev"
   },
   "repository": "https://github.com/pcamarajr/content-stack",
   "license": "MIT",

--- a/content-ops/.claude-plugin/plugin.json
+++ b/content-ops/.claude-plugin/plugin.json
@@ -2,7 +2,8 @@
   "name": "content-ops",
   "description": "Content creation and management plugin for static site blogs. Handles writing, translation, research, linking, style review, and knowledge indexing.",
   "author": {
-    "name": "pcamarajr"
+    "name": "pcamarajr",
+    "email": "eu@pcamarajr.dev"
   },
   "repository": "https://github.com/pcamarajr/content-stack",
   "license": "MIT",

--- a/content-seo/.claude-plugin/plugin.json
+++ b/content-seo/.claude-plugin/plugin.json
@@ -2,7 +2,8 @@
   "name": "content-seo",
   "description": "Site-level SEO intelligence layer for static content sites. Tracks performance via Google Search Console, surfaces ranking opportunities, diagnoses individual pages with live GSC data, audits GSC coverage/indexing errors, and injects keyword briefs into the content creation pipeline.",
   "author": {
-    "name": "pcamarajr"
+    "name": "pcamarajr",
+    "email": "eu@pcamarajr.dev"
   },
   "repository": "https://github.com/pcamarajr/content-stack",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Refactors `/astro-builder:audit` from a 145-line monolith into a thin orchestrator. The old Step 4.5 duplicated the `css-conventions` rules as an inline grep table — two sources of truth for the same rules (an information-hiding violation). Now each convention skill owns both its rules (`SKILL.md`) and their mechanical checks (`references/audit.md`), and the audit runs every domain through a checklist table where adding a new domain costs exactly one line.

## What changed

- **New `astro-builder/skills/css-conventions/references/audit.md`** — 13 mechanical checks (CSS-1 through CSS-13), each with the violation, detection command, severity (P0/P1/P2), confirmation guidance (a grep hit is a candidate, not a verdict), and suggested fix. Every check cites the rule section in `SKILL.md` it enforces.
- **`astro-builder/skills/audit/SKILL.md`** — rewritten in the canonical skill format: trigger-rich description, a short why-this-shape section, the audit's own steps kept intact (context loading, architecture, i18n, content schema, anti-slop + register logic, style guide, build validation, report format), a new **Domain checklists** step that enumerates per-skill `references/audit.md` files (one table row per domain), a pre-report verification checklist, and an orchestration-only constraint. The inline CSS grep table is gone.
- **`astro-builder/skills/css-conventions/SKILL.md`** — light retrofit: philosophy paragraph up front, pointer to the new `references/audit.md`, final verification checklist before Constraints, and fixed three stale `(Step 4)` cross-references that pointed at the wrong section for mandatory fallbacks.
- **Version bump** — astro-builder `1.3.0` → `1.4.0` in `marketplace.json`; audit skill description updated in the plugin README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)