### PR TITLE
refactor(astro-builder): retrofit translate/new-page/new-content-type to canonical skill format (v1.8.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,7 +30,7 @@
     {
       "name": "astro-builder",
       "description": "Build Astro 6 static content sites with Claude. Enforces best practices for i18n, content collections, the page-views pattern, and design systems. Starts with /astro-builder:init to scaffold a working, buildable site.",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "author": {
         "name": "pcamarajr",
         "email": "eu@pcamarajr.dev"

--- a/astro-builder/README.md
+++ b/astro-builder/README.md
@@ -47,9 +47,9 @@ If you want the fastest start, begin from the ready template:
 | `/astro-builder:init` | Show project setup dashboard |
 | `/astro-builder:init project` | Interview → generate guidance files AND scaffold a buildable site: config, BaseLayout, `src/lib/` utilities, i18n JSONs, content collections, RSS, 404, robots.txt |
 | `/astro-builder:init lighthouse` | Set up automated Lighthouse auditing on git push |
-| `/astro-builder:new-page` | Scaffold a page + page-view pair for all locales |
-| `/astro-builder:new-content-type` | Add a new content collection with schema, utilities, and example content |
-| `/astro-builder:translate` | Localize a content entry or i18n JSON to another locale |
+| `/astro-builder:new-page` | Scaffold a route for all locales: thin page wrappers (≤5 lines), a page-view wired to the BaseLayout SEO contract (`title`/`description`, `type="article"` + `publishedAt` for content pages), and i18n keys in every locale JSON |
+| `/astro-builder:new-content-type` | Add a content collection following the project contract: schema with `lang`/`translationKey`/`tags`/`draft`, a `getXByLang()` helper in `src/lib/content.ts`, a URL builder on `buildLocaleUrl`, and example content |
+| `/astro-builder:translate` | Localize a content entry or i18n JSON to another locale — same slug, target `lang`, matching `translationKey`; hreflang and RSS are derived by the architecture, no manual wiring |
 | `/astro-builder:audit` | Orchestrated project audit: architecture, i18n, schema, per-skill domain checklists (CSS, HTML/a11y, and SEO today), AI design slop, style guide, and build validation |
 | `css-conventions` _(auto-applied)_ | Enforces CSS discipline whenever styles are written: token-only values, scoped `<style>` blocks, Tier-1 modern CSS, no Tailwind / CSS-in-JS / preprocessors, and a CSS-first interactivity ladder |
 | `html-conventions` _(auto-applied)_ | Enforces semantic, accessible markup whenever templates are written: landmark structure (one `<main>`, one `<h1>`), unbroken heading hierarchy, button-vs-link discipline, ARIA only when no native element exists, explicit alt text, labeled forms, and focus order |

--- a/astro-builder/skills/new-content-type/SKILL.md
+++ b/astro-builder/skills/new-content-type/SKILL.md
@@ -1,35 +1,64 @@
 ---
-description: Add a new content type (Astro 6 content collection) to the project. Defines the schema in src/content.config.ts, creates example content files, and wires up utility functions. Arguments: content type name (e.g. "tutorials", "changelogs", "case-studies").
+description: >
+  Use this skill whenever adding a new kind of content to an astro-builder project — the user
+  asks to "add tutorials/changelogs/case studies", "create a new collection", "add a content
+  type", or wants entries that live in `src/content/` with their own schema. Trigger BEFORE
+  editing `src/content.config.ts` by hand: every collection in this stack follows one contract
+  (lang enum, translationKey, tags, draft), one query module (`src/lib/content.ts`), and one URL
+  builder (`src/lib/urls.ts`) — this skill creates all three together plus example content.
+  Arguments: content type name (e.g. "tutorials", "changelogs", "case-studies").
 ---
 
 # /astro-builder:new-content-type $ARGUMENTS
 
-You are adding a new Astro 6 content collection to this project. The argument is the collection name (e.g. `tutorials`, `changelogs`, `case-studies`).
+You are adding a new Astro 6 content collection to this project. The argument is the collection
+name (e.g. `tutorials`, `changelogs`, `case-studies`).
+
+**Why this workflow exists:** a content type is not just a schema — it is a contract spread
+across four files that must stay in agreement: the collection definition
+(`src/content.config.ts`), the query helpers (`src/lib/content.ts`), the URL builder
+(`src/lib/urls.ts`), and the content folders themselves. The contract fields (`lang`,
+`translationKey`, `tags`, `draft`) are what make the rest of the architecture free: `lang` +
+`translationKey` give every entry its translations and its hreflang alternates, `draft` keeps
+unpublished work out of listings and feeds, and routing all queries through `getXByLang()`
+keeps the three site-wide rules — filter by locale, exclude drafts, sort newest first — in
+exactly one place (information hiding: page-views ask for "this locale's tutorials" and stay
+ignorant of storage and ordering). A collection defined ad hoc drops one of these fields and the
+breakage shows up far away — an untranslatable entry, a draft in the RSS feed, a URL built three
+different ways.
+
+---
 
 ## Step 1 — Read project context
 
-1. Read `CLAUDE.md` and `.astro-builder/content-schema.md` to understand existing content types.
-2. Read `src/content.config.ts` to understand the existing collection definitions.
-3. Read `src/lib/content.ts` to understand the utility function patterns.
-4. Read `astro.config.ts` to get the i18n configuration (locales, default locale).
-5. Look at an existing content collection folder (e.g. `src/content/articles/`) to understand the folder structure.
+1. Read `CLAUDE.md` and `.astro-builder/content-schema.md` for the existing content types.
+2. Read `src/content.config.ts` for the existing collection definitions and the `locales` tuple.
+3. Read `src/lib/content.ts` and `src/lib/urls.ts` for the helper and builder patterns.
+4. Read `astro.config.ts` for the i18n configuration (locales, default locale).
+5. Look at an existing collection folder (e.g. `src/content/articles/`) for the folder layout.
 
 ## Step 2 — Interview the user
 
-Ask questions one at a time to define the new content type. Use the `AskUserQuestion` tool.
+Ask questions **one at a time** using the `AskUserQuestion` tool:
 
-Ask:
-1. What fields does this content type have? (title, date, author, tags, description, image, etc.)
-2. Are any fields optional? Which ones are required?
-3. Does this content type need to be translatable (i.e. support multiple locales)?
-4. Does this content type reference other collections (e.g. articles reference glossary entries)?
-5. What is the URL pattern for individual entries? (e.g. `/en/tutorials/[slug]`)
+1. What fields does this content type have beyond the skeleton (title, description, date,
+   tags)? — author, image, difficulty, version, etc.
+2. Which extra fields are required, which optional?
+3. Does it reference other collections (e.g. tutorials reference glossary entries)?
+4. What is the URL pattern for individual entries? (default: `/{locale}/{name}/{slug}/`)
 
-## Step 3 — Define the schema
+Do **not** ask whether it should be translatable or whether it needs `tags` — every collection
+gets the full contract (`lang`, `translationKey`, `tags`, `draft`). A type that is only authored
+in one locale today simply has entries in one locale folder; the contract costs nothing and
+keeps the door open.
 
-### 3.1 Update `src/content.config.ts`
+## Step 3 — Define the collection
 
-Add the new collection using Astro 6 `glob()` loader and `defineCollection()`. If multilingual:
+### 3.1 — Schema in `src/content.config.ts`
+
+Add the collection with the Astro 6 `glob()` loader, following the contract every collection in
+this stack shares. The `locales` tuple already at the top of the file is the single source of
+truth for the `lang` enum — reuse it, never restate the locales:
 
 ```typescript
 const tutorials = defineCollection({
@@ -39,69 +68,129 @@ const tutorials = defineCollection({
     description: z.string(),
     date: z.coerce.date(),
     tags: z.array(z.string()).default([]),
-    translationKey: z.string().optional(),
-    lang: z.enum(["en", "it"]).default("en"), // adjust to configured locales
-    // add fields from the interview
+    translationKey: z.string(),
+    lang: z.enum(locales),
+    draft: z.boolean().default(false),
+    // interview-specific fields go here
   }),
 });
 ```
 
-Export the collection in the `collections` object.
+Export it in the `collections` object.
 
-### 3.2 Create content folders
+| Bad | Good | Why |
+|---|---|---|
+| `tutorialsEn` + `tutorialsIt` collections | one collection, locale subfolders | one type = one schema; `lang` discriminates |
+| `lang: z.enum(["en", "it"])` restated inline | `lang: z.enum(locales)` | the tuple mirrors `astro.config.ts` once |
+| `translationKey: z.string().optional()` | `translationKey: z.string()` | optional linkage = entries that silently can't be translated |
+| `category: z.enum(["guide", "news"])` | `tags: z.array(z.string()).default([])` | fixed enums need a schema change per new label |
+| no `draft` field | `draft: z.boolean().default(false)` | drafts must be excludable from listings, feeds, sitemaps |
 
-For each configured locale, create the folder:
-- `src/content/{name}/en/`
-- `src/content/{name}/it/` (if multilingual)
+### 3.2 — Content folders and example entries
 
-Create one example `.md` file per locale with all required frontmatter fields populated with realistic placeholder content.
+Create one folder per configured locale: `src/content/tutorials/en/`, `src/content/tutorials/it/`,
+etc. Write one example `.md` entry in the default locale with every required field populated with
+realistic content (the build fails on an empty collection referenced by a page, and an example
+documents the frontmatter for authors).
 
-### 3.3 Update `src/lib/content.ts`
+### 3.3 — Query helpers in `src/lib/content.ts`
 
-Add utility functions for the new collection following the existing patterns:
+Add one `getXByLang()` following the module's pattern — filtering **inside** `getCollection()`
+so the locale filter and draft exclusion can't be separated, sorted newest first:
 
 ```typescript
-export async function getTutorialsByLang(lang: string) {
-  const all = await getCollection("tutorials");
-  return all
-    .filter((entry) => entry.data.lang === lang)
-    .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+export async function getTutorialsByLang(lang: string | undefined) {
+  const entries = await getCollection(
+    "tutorials",
+    ({ data }) => data.lang === lang && !data.draft,
+  );
+  return entries.toSorted(
+    (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
+  );
 }
 ```
 
-Add any other helpers that are appropriate (e.g. `getTutorialBySlug()`, `getAllTutorialTags()`).
-
-### 3.4 Update URL builders in `src/lib/urls.ts`
-
-Add a URL builder for this content type:
+Add narrower helpers (`getTutorialBySlug()`, `getAllTutorialTags()`) **only** when a page-view
+actually needs them — unused helpers are interface surface with no functionality behind it.
 
 ```typescript
+// 🔴 Bad: a page-view querying the collection itself — the three rules
+// (lang filter, draft exclusion, sort) get reimplemented and forgotten
+const all = await getCollection("tutorials");
+const visible = all.filter((t) => t.data.lang === Astro.currentLocale);
+
+// ✅ Good: one call, all three rules applied in one place
+const tutorials = await getTutorialsByLang(Astro.currentLocale);
+```
+
+### 3.4 — URL builder in `src/lib/urls.ts`
+
+Add one builder delegating to the `buildLocaleUrl` primitive. Entry ids from `glob()` loaders
+include the locale folder (`"en/my-tutorial"`) — strip it; the URL prefix carries the locale:
+
+```typescript
+export function buildTutorialUrl(slug: string, locale: string): string {
+  return buildLocaleUrl(locale, "tutorials", slug.replace(`${locale}/`, ""));
+}
+```
+
+```typescript
+// 🔴 Bad: hand-concatenated path — no trailing slash, locale shape duplicated
 export function buildTutorialUrl(slug: string, lang: string): string {
   return `/${lang}/tutorials/${slug}`;
 }
 ```
 
+### 3.5 — Document the type
+
+Add the new content type — fields, relationships, URL pattern — to
+`.astro-builder/content-schema.md`, which is the human-readable index of `src/content.config.ts`
+(the same way `design-system.md` indexes `global.css`).
+
 ## Step 4 — Scaffold pages (optional)
 
-Ask the user: "Do you want me to scaffold the listing page and detail page for this content type?"
-
-If yes, run `/astro-builder:new-page` for each needed page.
+Ask the user: "Do you want me to scaffold the listing page and detail page for this content
+type?" If yes, run `/astro-builder:new-page` for each — the detail page-view passes
+`type="article"` + `publishedAt` to BaseLayout (see `seo-conventions`). If this type becomes the
+site's primary dated collection, point the per-locale `rss.xml.ts` feeds at it; otherwise no
+feed work is needed.
 
 ## Step 5 — Verify
 
 Run `pnpm build` and `tsc --noEmit`. Fix any errors before finishing.
 
 Report:
-- Updated files and new files created
-- Schema definition summary
-- Example content file locations
-- Utility functions added
+
+- Updated and created files.
+- Schema summary (contract fields + interview fields).
+- Example entry locations, helpers, and URL builder added.
+
+Before reporting, confirm:
+
+- [ ] The collection lives in `src/content.config.ts` (never `src/content/config.ts`), uses the
+      `glob()` loader, and is exported in `collections`.
+- [ ] The schema carries the full contract: `lang: z.enum(locales)` (shared tuple), required
+      `translationKey`, `tags: z.array(z.string()).default([])`, `draft` defaulting to `false`.
+- [ ] One folder per configured locale exists, with at least one realistic example entry in the
+      default locale.
+- [ ] `src/lib/content.ts` has a `getXByLang()` filtering `lang` + `!draft` inside
+      `getCollection()` and sorting newest first.
+- [ ] `src/lib/urls.ts` has a builder delegating to `buildLocaleUrl`, stripping the locale
+      folder from the entry id.
+- [ ] `.astro-builder/content-schema.md` documents the new type.
+- [ ] `pnpm build` and `tsc --noEmit` pass.
 
 ## Constraints
 
-- Never create separate collections per language — one collection with lang subfolders.
+- Never create separate collections per language — one collection with locale subfolders;
+  `lang` discriminates.
 - Never use `src/content/config.ts` — always `src/content.config.ts`.
-- Always use `glob()` loader (Astro 6 pattern).
+- Always use the `glob()` loader (Astro 6 pattern).
 - Always use flexible `tags: string[]` — never fixed category enums.
-- Always use `translationKey` to link content across locales.
+- Always link locales via a **required** `translationKey`.
+- Page-views never call `getCollection()` — all queries go through `src/lib/content.ts`; all
+  internal URLs come from `src/lib/urls.ts`.
+- The init scaffolds for these contracts are `docs/init-templates/content.config.ts.template`,
+  `lib/content.ts.template`, and `lib/urls.ts.template` (plugin root) — keep this skill in sync
+  with them.
 - Always follow the Astro 6 documentation: https://docs.astro.build/llms-small.txt

--- a/astro-builder/skills/new-page/SKILL.md
+++ b/astro-builder/skills/new-page/SKILL.md
@@ -1,91 +1,213 @@
 ---
-description: Scaffold a new page in the Astro 6 project. Creates the page file(s), a matching page-view, wires i18n, and registers the route for all configured locales. Arguments: page name and optional path (e.g. "about" or "blog/archive").
+description: >
+  Use this skill whenever adding a route to an astro-builder project — the user asks to "add a
+  page", "create an about/pricing/contact page", "add a listing page", "scaffold a route", or
+  names a path like `blog/archive` or `tags/[tag]`. Trigger BEFORE creating any file under
+  `src/pages/` by hand: in this stack every route is a thin wrapper (≤5 lines) around a
+  page-view, created once per configured locale, with its strings registered in every locale
+  JSON. Creates the page files, the page-view, and the i18n keys, then verifies the build.
+  Arguments: page name or path (e.g. "about", "blog/archive", "tags/[tag]").
 ---
 
 # /astro-builder:new-page $ARGUMENTS
 
-You are scaffolding a new page in this Astro 6 project. The argument is the page name or path (e.g. `about`, `blog/archive`, `tags/[tag]`).
+You are scaffolding a new page in this Astro 6 project. The argument is the page name or path
+(e.g. `about`, `blog/archive`, `tags/[tag]`).
+
+**Why this workflow exists:** a page in this stack is three artifacts that must agree — one thin
+route file per locale, one page-view holding all logic and markup, and one set of i18n keys
+present in every locale JSON. The page-view is where the architecture's deep modules meet:
+`BaseLayout` receives `title` + `description` and derives the entire SEO `<head>`
+(seo-conventions), the layout owns the landmarks while the page-view supplies the single `<h1>`
+(html-conventions), `tl()` resolves every visible string (ux-writing), and `src/lib/` answers
+every data and URL question. A page created by hand tends to skip one of these agreements — a
+locale without the route, a key missing from one JSON, an `<h1>` that never appears — and each
+skipped agreement is a broken page in production. This workflow makes the agreements mechanical.
+
+---
 
 ## Step 1 — Read project context
 
 Before writing any code:
 
 1. Read `CLAUDE.md` and `.astro-builder/content-schema.md` to understand the project.
-2. Read `astro.config.ts` to get the i18n config (locales, default locale, routing).
-3. Read `src/i18n/en.json` (or the default locale file) to understand the translation key format.
-4. Look at an existing page in `src/pages/` to understand the thin-wrapper pattern.
-5. Look at an existing page-view in `src/page-views/` to understand the page-view pattern.
+2. Read `astro.config.ts` for the i18n config (locales, default locale, routing).
+3. Read the default locale file in `src/i18n/` (e.g. `src/i18n/en.json`) — keys are **flat and
+   dotted** (`"about.title"`), never nested objects.
+4. Read one existing page in `src/pages/` and one page-view in `src/page-views/` to match the
+   established pattern.
+5. If the page renders collection entries, read `src/lib/content.ts` (query helpers) and
+   `src/lib/urls.ts` (URL builders).
 
 ## Step 2 — Plan
 
-Based on the argument `$ARGUMENTS`, determine:
+From `$ARGUMENTS`, determine:
+
 - The page slug and any dynamic segments (e.g. `[tag]`, `[...slug]`).
-- Whether this page needs data from a content collection.
-- What i18n keys will be needed (page title, meta description, any UI strings).
+- Whether the page needs data from a content collection — if so, which `getXByLang()` helper
+  serves it (page-views never call `getCollection()` directly; if no helper exists, the content
+  type is missing — run `/astro-builder:new-content-type` first).
+- Whether this is a **content page** (renders one dated entry → `type="article"` +
+  `publishedAt` to BaseLayout) or an **index/landing page** (default `type="website"`).
+- The i18n keys to add: at minimum `{pageName}.title` and `{pageName}.description`, plus one key
+  per UI string on the page.
 
 Announce the plan: list the files you will create and the i18n keys you will add.
 
 ## Step 3 — Create files
 
-### 3.1 Page files (one per locale)
+### 3.1 — Page files: one thin wrapper per locale
 
 For each configured locale, create `src/pages/{locale}/{path}.astro`:
 
 ```astro
 ---
-import {PageViewName} from "@page-views/{PageViewName}.astro";
+import AboutPageView from "@page-views/AboutPageView.astro";
 ---
 
-<PageViewName />
+<AboutPageView />
 ```
 
-That is all. No imports of data, no props, no logic. The page is a thin wrapper.
+That is all — ≤5 lines, no data, no props, no logic. One file per locale; never collapse
+locales into a single `getStaticPaths`-driven page.
 
-### 3.2 Page-view file
+```astro
+<!-- 🔴 Bad: a "page" doing page-view work — locale logic, data, markup in the route file -->
+---
+import { getCollection } from "astro:content";
+const lang = Astro.url.pathname.split("/")[1];      // parsing the URL for locale
+const articles = await getCollection("articles");    // data fetching in a page
+---
+<html lang={lang}>...</html>
+```
 
-Create `src/page-views/{PageViewName}.astro`:
+```astro
+<!-- ✅ Good: the route exists, everything else lives in the page-view -->
+---
+import AboutPageView from "@page-views/AboutPageView.astro";
+---
+<AboutPageView />
+```
+
+### 3.2 — The page-view
+
+Create `src/page-views/{PageViewName}.astro`. The page-view resolves its own locale via
+`Astro.currentLocale` (never as a prop, never from the URL), passes the SEO contract to
+BaseLayout, and supplies the page's single `<h1>` — the layout already owns `<html lang>`, the
+skip link, `header`/`nav`/`main`/`footer`; the page-view fills `<main>` and never re-declares
+landmarks (see html-conventions).
+
+Index/landing page (strings via `tl()`):
 
 ```astro
 ---
-import { createTranslator } from "@lib/i18n";
 import BaseLayout from "@layouts/BaseLayout.astro";
+import { createTranslator } from "@lib/i18n";
 
 const tl = createTranslator(Astro.currentLocale);
-const locale = Astro.currentLocale ?? "en";
-
-// Data fetching goes here if needed
 ---
 
-<BaseLayout title={tl("pageName.title")} description={tl("pageName.description")}>
-  <!-- Page markup here -->
+<BaseLayout title={tl("about.title")} description={tl("about.description")}>
+  <h1>{tl("about.title")}</h1>
+  <!-- page markup -->
 </BaseLayout>
 ```
 
-### 3.3 Add i18n keys
+Content page (one dated entry — the SEO contract grows to `type` + `publishedAt`, and `image`
+when the entry has one):
 
-For each locale JSON file in `src/i18n/`, add the required translation keys:
-- `{pageName}.title` — page title
-- `{pageName}.description` — meta description
-- Any other UI strings specific to this page
+```astro
+---
+import BaseLayout from "@layouts/BaseLayout.astro";
+const { entry } = Astro.props;
+---
 
-### 3.4 Dynamic pages
+<BaseLayout
+  title={entry.data.title}
+  description={entry.data.description}
+  type="article"
+  publishedAt={entry.data.date}
+>
+  <h1>{entry.data.title}</h1>
+  <!-- entry markup -->
+</BaseLayout>
+```
 
-If the route has a dynamic segment (e.g. `[tag]`), add `getStaticPaths()` to the page-view, not the page file.
+| Bad | Good | Why |
+|---|---|---|
+| `<meta>` / canonical / OG tags in the page-view | pass `title`, `description` (+ `type`, `publishedAt`) to BaseLayout | the `<head>` is a deep module — seo-conventions §1 |
+| article page without `type="article"` | `type="article"` + `publishedAt={entry.data.date}` | drives `article:published_time` + Article JSON-LD |
+| no `<h1>`, or `<h1>` in a component | exactly one `<h1>` in the page-view, inside `<main>` | the page-view owns the page title — html-conventions §1 |
+| `const lang = Astro.url.pathname.split("/")[1]` | `Astro.currentLocale` | the framework already knows the locale |
+| `href={\`/${locale}/articles/${slug}\`}` | builders from `@lib/urls` (`buildLocaleUrl`, `buildArticleUrl`, …) | one module knows the URL shape |
+| `<p>Read more</p>` hardcoded | `tl("about.readMore")` | every visible string routes through i18n — ux-writing |
+
+### 3.3 — i18n keys, in every locale file
+
+Add the new keys to **every** `src/i18n/{locale}.json` — flat dotted keys, same key set in every
+file (a key present in one locale and missing in another is a contract violation; `MessageKey`
+is typed from the default locale, so a missing default-locale key is a TypeScript error):
+
+```json
+{
+  "about.title": "About us",
+  "about.description": "Who we are and why we build in the open."
+}
+```
+
+The `description` value is the page's SERP pitch — ~70–160 characters (seo-conventions §2).
+Write the default-locale copy first under the `ux-writing` skill, then translate the same keys
+for the other locales (or run `/astro-builder:translate src/i18n/{default}.json {locale}`).
+
+### 3.4 — Dynamic pages
+
+For dynamic segments (e.g. `tags/[tag]`), `getStaticPaths()` lives in the page-view; the page
+file stays thin by re-exporting it:
+
+```astro
+---
+import TagPageView from "@page-views/TagPageView.astro";
+export { getStaticPaths } from "@page-views/TagPageView.astro";
+---
+
+<TagPageView />
+```
+
+Inside the page-view, read the segment from `Astro.params` and fetch entries through the
+`@lib/content` helpers. `getStaticPaths` enumerates the segment values only — the locale comes
+from the folder, never from a path param.
 
 ## Step 4 — Verify
 
-Run `pnpm build`. If there are TypeScript or build errors, fix them before finishing.
+Run `pnpm build`. Fix any TypeScript or build errors before finishing.
 
 Report what was created:
-- List all new files
-- List all i18n keys added
-- Show the URL(s) the page will be available at (e.g. `/en/about`, `/it/chi-siamo`)
+
+- All new files (pages + page-view).
+- All i18n keys added, confirming they exist in every locale file.
+- The URL(s) the page is available at, one per locale (e.g. `/en/about/`, `/it/about/`).
+
+Before reporting, confirm:
+
+- [ ] One page file per configured locale exists; each is ≤5 lines with no logic.
+- [ ] The page-view passes `title` and `description` to BaseLayout — and `type="article"` +
+      `publishedAt` (+ `image` when available) if it renders a dated content entry.
+- [ ] No SEO tag (`<meta>`, canonical, OG/Twitter, JSON-LD) was written outside BaseLayout.
+- [ ] The page-view renders exactly one `<h1>` and re-declares no landmark.
+- [ ] Every new i18n key exists in **every** locale JSON, flat dotted format.
+- [ ] All visible strings route through `tl()` — nothing hardcoded.
+- [ ] Internal links use `@lib/urls` builders; collection data comes from `@lib/content` helpers.
+- [ ] `pnpm build` passes.
 
 ## Constraints
 
 - Never put data fetching, props, or logic in page files — pages are thin wrappers only.
-- Never hardcode UI strings in `.astro` files — always use `tl('key')`.
-- Never parse `Astro.url` to detect locale — always use `Astro.currentLocale`.
-- Always create one page file per locale (do not use `getStaticPaths` to handle locales in a single page).
-- Follow the path alias conventions from `CLAUDE.md` (`@/*`, `@components/*`, etc.).
+- Never hardcode UI strings in `.astro` files — always `tl("key")` (see `ux-writing`).
+- Never parse `Astro.url` to detect locale — always `Astro.currentLocale`, and never thread the
+  locale (or `tl`) down as a prop.
+- Always create one page file per locale — never use `getStaticPaths` to fan out locales.
+- Never call `getCollection()` in a page-view — go through `src/lib/content.ts`.
+- Follow the path aliases from `tsconfig.json` (`@page-views/*`, `@layouts/*`, `@lib/*`, …).
+- Markup, SEO, copy, and CSS rules come from the convention skills: `html-conventions`,
+  `seo-conventions`, `ux-writing`, `css-conventions`.
 - Always follow the Astro 6 documentation: https://docs.astro.build/llms-small.txt

--- a/astro-builder/skills/translate/SKILL.md
+++ b/astro-builder/skills/translate/SKILL.md
@@ -1,76 +1,163 @@
 ---
-description: Translate a content entry or page to another locale. Reads the source file, translates content while preserving frontmatter structure and markdown formatting, creates the translated file in the correct locale folder, and links it via translationKey. Arguments: file path and target locale (e.g. "src/content/articles/en/hello-world.md it").
+description: >
+  Use this skill whenever localizing anything in an astro-builder project — the user asks to
+  "translate this article to Italian", "localize the site to French", "add the German version of
+  this page", "translate the i18n file", or names a content file plus a target locale. Trigger
+  BEFORE translating any `src/content/` entry or `src/i18n/` JSON by hand: translated entries
+  must keep their slug, carry the right `lang`, and link to the source via `translationKey` —
+  that linkage is what makes hreflang alternates and the locale's RSS feed appear with zero
+  manual work. Arguments: file path and target locale (e.g.
+  "src/content/articles/en/hello-world.md it" or "src/i18n/en.json it").
 ---
 
 # /astro-builder:translate $ARGUMENTS
 
-You are translating content in this Astro 6 project. The argument format is: `{file-path} {target-locale}` (e.g. `src/content/articles/en/hello-world.md it`).
+You are localizing content in this Astro 6 project. The argument format is
+`{file-path} {target-locale}` (e.g. `src/content/articles/en/hello-world.md it`).
+
+**Why this workflow exists:** in this architecture, translation is a *content* operation, never
+a *plumbing* operation. Because every collection carries `lang` + `translationKey`, every route
+is locale-prefixed, and BaseLayout derives hreflang alternates while `rss.xml.ts` feeds each
+locale — a correctly placed translated file gets its URL, its hreflang alternates, and its RSS
+entry automatically. No `<link>` to add, no feed to touch, no route to register. The entire
+job is therefore *quality of localization* plus *three frontmatter facts kept true*: same slug,
+target `lang`, matching `translationKey`. Get those wrong and the architecture silently
+disconnects the translation from its source; get them right and everything else is derived.
+And localization means localization: a word-for-word translation reads machine-made and betrays
+the voice that `.astro-builder/style-guide.md` defines — adapt, don't transliterate.
+
+---
 
 ## Step 1 — Parse arguments and read context
 
 Parse `$ARGUMENTS` to extract:
+
 - `sourcePath`: the file to translate
 - `targetLocale`: the target language code (e.g. `it`, `fr`, `de`)
 
 Then read:
-1. `CLAUDE.md` and `.astro-builder/style-guide.md` for tone, voice, and writing conventions.
-2. `astro.config.ts` to confirm the target locale is configured.
+
+1. `CLAUDE.md` and `.astro-builder/style-guide.md` — voice, tone, and the project's
+   translation/localization rules (the style guide has a dedicated section; follow it).
+2. `astro.config.ts` — confirm the target locale is configured.
 3. The source file at `sourcePath`.
-4. Any existing translated files in the target locale folder to understand the expected style.
-5. `src/i18n/{targetLocale}.json` to understand translated UI strings (reference only).
+4. Existing translations in the target locale folder — match their established style and
+   terminology.
+5. `src/i18n/{targetLocale}.json` — the already-translated UI strings are the project's de facto
+   glossary for recurring terms (reference only).
 
 ## Step 2 — Validate
 
-Check:
-- The target locale exists in `astro.config.ts`. If not, stop and inform the user.
+- The target locale exists in `astro.config.ts` `i18n.locales`. If not, stop and tell the user —
+  adding a locale is a config + i18n-file change, not a translation.
 - The source file exists. If not, stop and inform the user.
-- A translation doesn't already exist (look for a file with the same slug in the target locale folder). If it exists, ask the user whether to overwrite or create a new version.
+- A translation does not already exist (same slug in the target locale folder). If it does, ask
+  the user whether to overwrite.
 
 ## Step 3 — Translate the content
 
-This is **localization**, not word-for-word translation. Apply these rules:
+This is **localization**, not word-for-word translation:
 
-- Preserve all frontmatter fields. Translate: `title`, `description`, and any text fields. Do NOT translate: `date`, `tags` (translate their meaning but keep slugs consistent), `translationKey`, `lang` (change to target locale value), `slug`.
-- Translate the body content naturally, matching the tone and voice defined in `.astro-builder/style-guide.md`.
-- Preserve all markdown formatting: headings, bold, italic, code blocks, links, lists.
-- Preserve all relative links (they remain the same path).
-- Do NOT translate code blocks — only translate comments within code blocks if present.
-- Adapt cultural references, idioms, and examples to feel natural in the target language — do not translate literally.
-- Keep technical terms consistent. If a glossary or term list exists in `.astro-builder/`, follow it.
+- Match the voice and tone defined in `.astro-builder/style-guide.md` — translation must not
+  flatten it.
+- Adapt idioms, cultural references, and examples to feel native in the target language.
+- Keep technical terms consistent: translate a term only if a widely accepted translation exists;
+  otherwise keep the original. Follow any glossary in `.astro-builder/`.
+- Preserve all markdown formatting: headings, emphasis, code blocks, links, lists.
+- Do **not** translate code blocks — only comments inside them.
+- Preserve relative links as-is (slugs never change across locales, so paths stay valid).
+
+| Bad | Good | Why |
+|---|---|---|
+| literal, word-order-preserving translation | natural phrasing a native writer would choose | machine-sounding copy betrays the voice |
+| translating an idiom literally | an equivalent idiom or plain restatement | idioms don't cross languages |
+| translating identifiers in a code block | code untouched, comments translated | code is not prose |
+| inventing new terminology per file | reuse terms from existing translations and `src/i18n/{targetLocale}.json` | one term per concept, everywhere |
+
+Frontmatter rules:
+
+- Translate: `title`, `description`, and any other prose fields. Keep `description` at
+  ~70–160 characters — it is the page's SERP pitch (see `seo-conventions`).
+- Do **not** translate: `date`, `translationKey`, tag slugs (`tags` stay identical across
+  locales so tag pages aggregate correctly), or any field that is an identifier.
+- Set: `lang: {targetLocale}`. Preserve `draft` exactly as the source has it.
 
 ## Step 4 — Create the translated file
 
-Determine the output path:
-- Source: `src/content/articles/en/hello-world.md`
-- Target: `src/content/articles/it/hello-world.md`
+The output path mirrors the source with only the locale folder changed — **the slug (filename)
+never changes**:
 
-The slug (filename) stays the same across locales.
+```text
+🔴 Bad:  src/content/articles/en/hello-world.md → src/content/articles/it/ciao-mondo.md
+✅ Good: src/content/articles/en/hello-world.md → src/content/articles/it/hello-world.md
+```
 
-Update frontmatter:
-- Set `lang: {targetLocale}`
-- Ensure `translationKey` is set and matches the source file. If the source doesn't have a `translationKey`, generate one (use the slug) and add it to both files.
+A translated slug breaks the `translationKey` symmetry readers and tooling rely on — the locale
+prefix in the URL is the only thing that differs between language versions.
 
-Write the translated file.
+Frontmatter linkage:
+
+- `lang: {targetLocale}`.
+- `translationKey` identical to the source's. The schema requires it; if a legacy source file is
+  missing it, generate one from the slug and add it to **both** files.
+
+Write the translated file. That is the whole job: because the file now sits in the right locale
+folder with the right `lang` and `translationKey`, the architecture derives the rest — the page
+appears at `/{targetLocale}/...`, BaseLayout emits its hreflang alternates, and the locale's
+`rss.xml.ts` picks it up. Adding any of those by hand is a violation, not a favor.
 
 ## Step 5 — Verify
 
-1. Check that both source and target files have matching `translationKey` values.
+1. Source and target frontmatter have **identical** `translationKey` values.
 2. Run `pnpm build`. Fix any errors before finishing.
 
 Report:
-- Source file translated
-- Output file created
-- `translationKey` used to link them
-- Any cultural adaptations or notable translation decisions made
+
+- Source file translated and output file created.
+- The `translationKey` linking them.
+- Notable localization decisions (adapted idioms, kept-original technical terms, cultural
+  substitutions).
+
+Before reporting, confirm:
+
+- [ ] The target file sits in the target locale folder with the **same slug** as the source.
+- [ ] `lang` is the target locale; `translationKey` matches the source exactly; `draft` status
+      is preserved.
+- [ ] `date`, tag slugs, and identifiers are untouched; prose fields are localized.
+- [ ] `description` is ~70–160 characters and reads naturally in the target language.
+- [ ] Markdown structure is intact; code blocks untranslated; relative links unchanged.
+- [ ] No hreflang, RSS, or routing work was done by hand — the architecture derives it.
+- [ ] `pnpm build` passes.
 
 ## Translating i18n UI strings
 
-If `$ARGUMENTS` refers to an i18n JSON file (e.g. `src/i18n/en.json it`), translate all string values from the source locale JSON to create the target locale JSON. Preserve all keys exactly. Keep placeholders like `{count}`, `{name}` unchanged.
+If `$ARGUMENTS` points at an i18n JSON (e.g. `src/i18n/en.json it`), translate the string
+*values* into a new `src/i18n/{targetLocale}.json`:
+
+- **Keys are identical across locales** — same flat dotted keys (`"layout.skipToContent"`),
+  same key set, nothing added, nothing dropped. `MessageKey` is typed from the default locale;
+  a missing key in another locale falls back to the default at runtime, which is a translation
+  hole, not a feature.
+- Keep placeholders like `{count}` and `{name}` byte-identical.
+- UI copy follows the `ux-writing` skill: keep labels verb+object, keep terminology consistent
+  with the strings already in the file.
+
+```json
+// 🔴 Bad: keys "translated", one key dropped
+{ "layout.saltaAlContenuto": "Salta al contenuto" }
+
+// ✅ Good: same keys, localized values, placeholders intact
+{ "layout.skipToContent": "Salta al contenuto", "notFound.title": "Pagina non trovata" }
+```
 
 ## Constraints
 
-- Never machine-translate mechanically — localize for natural reading.
-- Never change slugs/filenames when translating.
-- Always link source and target via `translationKey`.
-- Always follow `.astro-builder/style-guide.md` for tone and voice.
-- Follow MDN Web API references for any web-related terminology.
+- Never machine-translate mechanically — localize for natural reading in the target language.
+- Never change slugs/filenames or tag slugs when translating.
+- Always link source and target via an identical `translationKey`.
+- Always follow `.astro-builder/style-guide.md` for voice, tone, and terminology.
+- Never hand-write hreflang links, RSS items, or routes for a translation — placement +
+  frontmatter make the architecture derive them (see `seo-conventions`).
+- i18n JSONs keep identical flat dotted key sets across all locales; placeholders unchanged.
+- Follow MDN Web API references for any web-related terminology; always follow the Astro 6
+  documentation: https://docs.astro.build/llms-small.txt


### PR DESCRIPTION
## Summary

Phase 2 of the astro-builder production-ready plan: the three remaining procedural skills are rewritten in the canonical skill format (trigger-rich frontmatter description, philosophy/why section, good/bad contrasts, phased workflow, verification checklist, closing constraints) and aligned with the contract that `/astro-builder:init` now scaffolds from `docs/init-templates/`. No purpose changes, no new features — format retrofit + contract alignment.

## Changes

- **`astro-builder/skills/new-page/SKILL.md`** — page-views now use BaseLayout as the SEO deep module (`title` + `description` required; `type="article"` + `publishedAt` for content pages), supply the page's single `<h1>` while landmarks stay in the layout, register flat-dotted i18n keys in every locale JSON, fetch data through `@lib/content` helpers, and build hrefs via `@lib/urls`. Dynamic routes keep `getStaticPaths` in the page-view with a thin re-exporting wrapper.
- **`astro-builder/skills/new-content-type/SKILL.md`** — schema follows `content.config.ts.template`: shared `locales` tuple for the `lang` enum, **required** `translationKey`, `tags: string[]`, `draft`. Helpers follow the `getXByLang()` pattern (lang + `!draft` filtered inside `getCollection()`, newest-first); URL builders delegate to the `buildLocaleUrl` primitive and strip the glob-loader locale folder. New types get documented in `.astro-builder/content-schema.md`.
- **`astro-builder/skills/translate/SKILL.md`** — format retrofit; makes the same-slug / target-`lang` / matching-`translationKey` contract explicit, keeps i18n JSON key sets identical across locales (flat dotted keys, placeholders untouched), and states that translated pages gain hreflang alternates and RSS entries automatically via the architecture — hand-wiring them is a violation.
- **`.claude-plugin/marketplace.json`** — astro-builder bumped to **1.8.0** (validated with `python3 -m json.tool`).
- **`astro-builder/README.md`** — skill table rows for the three skills updated to reflect the contracts they now enforce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)