### PR TITLE
fix(astro-builder): correct nesting-vs-unclosed-tag build error claim

### DIFF
--- a/astro-builder/README.md
+++ b/astro-builder/README.md
@@ -211,8 +211,9 @@ itself (based on John Ousterhout's *A Philosophy of Software Design*).
 - `translationKey` to link content across locales
 - Flexible `tags: string[]` (never fixed category enums)
 - Node.js >= 22.12.0 (Astro 7 engine requirement)
-- Every tag explicitly closed and no invalid nesting — the Astro 7 Rust compiler errors instead of
-  auto-correcting
+- Every tag explicitly closed — the Astro 7 Rust compiler errors on an unclosed tag
+- No invalid nesting — the Rust compiler no longer auto-corrects it; the browser gets the markup as
+  authored
 
 ### Tooling
 

--- a/astro-builder/docs/architecture.md
+++ b/astro-builder/docs/architecture.md
@@ -17,9 +17,10 @@ modules.
 ## Part 1 — The code the builder generates
 
 Astro 7 moves two concerns that used to be cosmetic into the correctness column. Its Rust compiler
-no longer auto-corrects markup, so an unclosed tag or a block element nested inside a `<p>` fails
-the build instead of being silently repaired; and the new `compressHTML: 'jsx'` default strips
-whitespace JSX-style, so significant space between inline elements has to be written explicitly.
+fails the build on an unclosed tag and no longer repairs invalid markup, so a block element nested
+inside a `<p>` reaches the browser exactly as authored; and the new `compressHTML: 'jsx'` default
+strips whitespace JSX-style, so significant space between inline elements has to be written
+explicitly.
 Both are rules, not criteria, and they belong to `skills/html-conventions/SKILL.md` — the point
 here is only that "the markup renders anyway" is no longer an argument.
 

--- a/astro-builder/skills/audit/SKILL.md
+++ b/astro-builder/skills/audit/SKILL.md
@@ -56,6 +56,9 @@ Then check the rest:
 - **Stabilized experimental flags**: `experimental.logger`, `experimental.cache` and
   `experimental.routeRules` moved to the top level (`logger`, `cache`, `routeRules`) — P1, fix is to
   hoist them out of `experimental`.
+- **Still-experimental flags are not findings**: `experimental.collectionStorage` (Astro 7.1, default
+  `'single-file'`) is current API — leave it alone. An `experimental` key holding only flags Astro 7
+  still ships is configuration, not a violation.
 - **Reserved routing entrypoint**: `src/fetch.ts` must not exist unless it is a deliberate
   advanced-routing entrypoint. Otherwise flag P1 — rename the file, or set
   `fetchFile: './src/router.ts'` / `fetchFile: null` in `astro.config.ts`.
@@ -150,17 +153,18 @@ This is a best-effort check — report findings but don't auto-fix style issues.
 
 Run `pnpm build`. If it fails, include the full error output in the report. **Severity follows the
 convention rule the failure maps to** — a build error that a domain checklist already owns is
-reported at that rule's severity (e.g. a block element inside a `<p>` is HTML-13, a P1), not
-automatically P0. A build failure that maps to no convention rule is a **P0**.
+reported at that rule's severity (e.g. an unclosed tag is HTML-12, a P0), not automatically P0 by
+default. A build failure that maps to no convention rule is a **P0**.
 Run `tsc --noEmit`. Include any TypeScript errors as P0 issues.
 Run `biome check .` if Biome is configured. Include lint errors as P1 issues.
 
 Two Astro 7 failure modes to name explicitly when they show up:
 
-- A build error about an **unclosed tag** or a **block element inside a `<p>`** is Astro 7
-  Rust-compiler strictness — the compiler errors where Astro 6 auto-corrected. Report it under the
-  html-conventions rule it belongs to (`references/audit.md`: HTML-12 for unclosed tags, HTML-13 for
-  a block element inside a `<p>`), at that rule's severity, with the fix at `file:line`.
+- A build error about an **unclosed tag** is Astro 7 Rust-compiler strictness — the compiler errors
+  where Astro 6 silently accepted it. Report it as HTML-12 (`references/audit.md`) with the fix at
+  `file:line`. **Invalid nesting does not error**: the Rust compiler passes the markup through
+  as-is and leaves the browser to handle it, so a green build says nothing about HTML-13 — that rule
+  is only ever caught by its own grep-plus-inspection check in Step 5, never here.
 - An install or build failure with no other explanation is usually **Node < 22.12.0**. Check `node -v`
   against Astro 7's `engines.node: ">=22.12.0"` before chasing anything else.
 

--- a/astro-builder/skills/init/rounds/project.md
+++ b/astro-builder/skills/init/rounds/project.md
@@ -195,7 +195,9 @@ Config first (aliases and locales must exist before code that uses them), then t
    longer exist). Grep for the key, not the bare word — the template mentions `experimental` in a
    comment on purpose.
 7. Every scaffolded `.astro` file has all tags closed and valid nesting — no block element inside a
-   `<p>`. Astro 7's Rust compiler errors on both instead of auto-correcting.
+   `<p>`. Astro 7's Rust compiler errors on an unclosed tag; invalid nesting it passes through
+   as-is, so a passing build in 4.5 proves the first half of this check and nothing about the
+   second — read the nesting.
 8. `package.json` carries `"engines": { "node": ">=22.12.0" }` (Phase 4.1 step 3).
 9. No template instruction block survived into `src/`: `grep -rn "DELETE THIS COMMENT" src` must
    return nothing.
@@ -204,8 +206,9 @@ Config first (aliases and locales must exist before code that uses them), then t
 
 1. Run `pnpm install`.
 2. Run `pnpm build` — the scaffold is not done until it passes. Fix errors autonomously and re-run.
-   A build error naming an unclosed tag or invalid nesting is Astro 7 compiler strictness, not a
-   template bug — close the tag / fix the nesting. A build error naming a remark or rehype plugin
+   A build error naming an unclosed tag is Astro 7 compiler strictness, not a template bug — close
+   the tag. Invalid nesting never surfaces here (the compiler ships it as authored), which is why
+   4.4 step 7 asks you to read it. A build error naming a remark or rehype plugin
    means the default Sätteri processor is in use: `pnpm add @astrojs/markdown-remark`, then
    `import { unified } from "@astrojs/markdown-remark"` and set `markdown: { processor: unified() }`.
 
@@ -247,7 +250,7 @@ What's next? Run `/astro-builder:init lighthouse` to add automated Lighthouse au
 - Never create `src/fetch.ts` — it is Astro 7's reserved advanced-routing entrypoint.
 - Never install `@astrojs/db` — it is removed in Astro 7.
 - Never use removed `experimental.*` flags — `logger`, `cache` and `routeRules` are top-level; `queuedRendering`, `rustCompiler` and `advancedRouting` are gone.
-- Always close every tag and keep nesting valid — the Astro 7 compiler errors instead of correcting.
+- Always close every tag (the Astro 7 compiler errors on an unclosed one) and keep nesting valid (it no longer corrects invalid nesting — the browser gets the markup as authored).
 - Never use ESLint or Prettier — always Biome.
 - Never parse URLs to detect locale — always use `Astro.currentLocale`.
 - Never use `redirectToDefaultLocale: true` — use explicit `redirects` config.

--- a/astro-builder/skills/seo-conventions/references/audit.md
+++ b/astro-builder/skills/seo-conventions/references/audit.md
@@ -13,9 +13,9 @@ Before running: identify the layout file (`src/layouts/BaseLayout.astro` or equi
 `astro.config.ts` — several checks treat the layout as the one legitimate home for SEO markup,
 and three checks read the config directly. These checks audit only the site's code; search
 performance data (GSC, keywords) is the `content-seo` plugin's territory and is out of scope.
-Note that an Astro 7 `astro.config.ts` may legitimately carry top-level `compressHTML`, `logger`,
-`cache`, or `routeRules` keys (Astro 7 stabilized them) — their presence is configuration, not a
-finding.
+Note that an Astro 7 `astro.config.ts` may legitimately carry top-level `logger`, `cache`, or
+`routeRules` keys (Astro 7 stabilized them out of `experimental`), alongside `compressHTML` (already
+top-level in v6, only its default changed) — their presence is configuration, not a finding.
 
 ---
 


### PR DESCRIPTION
## Summary
- Astro 7's Rust compiler only fails the build on an **unclosed tag**; **invalid nesting** passes through unchanged and reaches the browser as authored. The plugin docs conflated the two in 5 places, telling the audit skill to catch nesting violations (HTML-13) from build output — where they can never appear — so nesting bugs would ship past a green build while the audit reported everything clean.
- Also acquits `experimental.collectionStorage` (still-valid Astro 7.1 config, not a finding) and corrects `compressHTML`'s stabilization history (it was already top-level pre-v7, only its default changed).

Found during code review of #52 (the original Astro 7 targeting PR), applied on that branch but left uncommitted when #52 merged — landing now as a standalone follow-up fix.

## Test plan
- [x] Diffed against current `main` to confirm the bug is still present there
- [ ] Re-run `astro-builder`'s `audit` skill against a real Astro 7 project with a deliberate nesting violation to confirm it's still caught via the HTML-13 grep step (not via build output)